### PR TITLE
Add SSO/RBAC provisioning: org-manager tools, atomic provision/offboard, v2→v1 role assignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/
 # Local smoke-test / debug scripts — machine-specific paths & infra IDs, not committed
 auth-smoketest.mjs
 mcp-handshake-test.mjs
+verify-sso-live.mjs

--- a/README.md
+++ b/README.md
@@ -2,18 +2,21 @@
 
 An [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server for [Zitadel](https://zitadel.com/) identity management. Manage users, projects, applications, roles, and service accounts through natural language from AI tools like Claude Code.
 
-> *"Create a user for jane@example.com, assign her the app:finance role, and give me the auth config."*
-> — That's three tool calls the AI handles for you.
+> *"Provision jane@example.com as an Admin."*
+> — One tool call: creates the user, assigns the `admin` project role (v2 authorization), and grants `ORG_USER_MANAGER` so she can manage other users — no Super Admin required.
 
-## Tools (25)
+## Tools (33)
 
 | Category | Tool | Description |
 |----------|------|-------------|
 | **Users** | `zitadel_list_users` | List/search users |
 | | `zitadel_get_user` | Get user details |
-| | `zitadel_create_user` | Create user (sends invite email) |
+| | `zitadel_create_user` | Create user (sends invite email; optional client-supplied `userId`) |
 | | `zitadel_deactivate_user` | Deactivate user |
 | | `zitadel_reactivate_user` | Reactivate user |
+| | `zitadel_lock_user` | Lock user |
+| | `zitadel_unlock_user` | Unlock user |
+| | `zitadel_delete_user` | Permanently delete user |
 | **Projects** | `zitadel_list_projects` | List projects |
 | | `zitadel_get_project` | Get project details |
 | | `zitadel_create_project` | Create project |
@@ -22,20 +25,33 @@ An [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server for [
 | | `zitadel_create_oidc_app` | Create OIDC application |
 | | `zitadel_update_app` | Update app (redirect URIs, etc.) |
 | **Roles** | `zitadel_list_project_roles` | List roles in a project |
-| | `zitadel_create_project_role` | Create a role (e.g., `app:finance`) |
+| | `zitadel_create_project_role` | Create a role (standardized: `admin`/`standard`) |
 | | `zitadel_list_user_grants` | List user's role grants |
-| | `zitadel_create_user_grant` | Assign roles to user |
+| | `zitadel_create_user_grant` | Assign project roles (v2 authorization; flags off-vocabulary drift) |
 | | `zitadel_remove_user_grant` | Remove role grant |
+| **Org Managers** | `zitadel_list_org_manager_roles` | List supported manager roles (ORG_OWNER, ORG_USER_MANAGER, …) |
+| | `zitadel_list_org_managers` | List who holds manager grants (filter by role) |
+| | `zitadel_grant_org_manager` | Grant manager role(s) (default `ORG_USER_MANAGER`); idempotent |
+| | `zitadel_revoke_org_manager` | Revoke manager role(s); guards the last `ORG_OWNER` |
+| **Provisioning** | `zitadel_provision_user` | Atomic + idempotent: create user + assign `admin`/`standard` + (for Admins) `ORG_USER_MANAGER` |
+| | `zitadel_offboard_user` | Remove role + revoke manager + deactivate; guards last-Admin & self-demotion |
 | **Service Accounts** | `zitadel_create_service_user` | Create machine user |
 | | `zitadel_create_service_user_key` | Generate key pair |
 | | `zitadel_list_service_user_keys` | List keys (metadata only) |
 | **Organizations** | `zitadel_get_org` | Get current org details |
-| | `zitadel_list_orgs` | List organizations |
 | **Utility** | `zitadel_get_auth_config` | Get .env.local template for an app |
 | **Portal** | `portal_register_app` | Register app in portal DB |
 | | `portal_setup_full_app` | One-click: Zitadel + portal setup |
 
 Portal tools (`portal_*`) are only available when `PORTAL_DATABASE_URL` is configured.
+
+### Two-role model & no-super-admin (Renewal Initiatives SSO)
+
+The provisioning tools implement a standardized RBAC model for the core apps:
+
+- **Two project (business) roles only:** `admin` and `standard` — these land in the OIDC token and gate what a user can do in the apps. The provisioning tools refuse any other key to prevent drift.
+- **No Super Admin:** every Admin also receives an org-level `ORG_USER_MANAGER` grant (a *manager* role — administers Zitadel itself, not in the token), so any Admin can create/manage any user, including other Admins. Keep ≥2 `ORG_OWNER` break-glass accounts for org configuration.
+- **Role assignment prefers the v2 `AuthorizationService`** (`POST /v2/authorizations`) and **automatically falls back to v1 user-grants** if that endpoint is unavailable on the instance (some Zitadel Cloud versions return 404). Org-manager grants use the Management v1 org-member API.
 
 ## Prerequisites
 
@@ -105,7 +121,7 @@ Restart Claude Code after adding the config. The Zitadel tools will appear autom
 
 **This server has admin-level access to your Zitadel instance.** Understand what that means before using it:
 
-- The service account needs **Org Owner** (or **IAM Admin** for `zitadel_list_orgs`). It can create users, modify roles, and manage applications in your organization.
+- The service account needs org-level management rights. Empirically (Zitadel Cloud, verified 2026-06): `ORG_USER_MANAGER` is enough to **create users and assign existing project roles**, but **`ORG_OWNER` is required** to create project roles, manage org-manager grants (the no-super-admin pattern), and manage applications. For the full provisioning workload, give the service account `ORG_OWNER`; human Admins can stay at `ORG_USER_MANAGER`. Keep the key in a gitignored `.env` (not a shared dotfile) and use `ZITADEL_READ_ONLY=true` for non-mutating sessions.
 - When you create an OIDC app (`zitadel_create_oidc_app`), the **client secret** is returned in the tool response. It is only available at creation time. The AI assistant (and its conversation history) will see it — save it immediately and treat it as sensitive.
 - When you generate a service account key (`zitadel_create_service_user_key`), the **full private key** is returned in the tool response. Same caveat: save it, and be aware it's visible in your MCP client's conversation.
 - All tool arguments containing PII (email, name, URLs) are **redacted from debug logs**. IDs and tool names are still logged.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zitadel-mcp-server",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zitadel-mcp-server",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zitadel-mcp-server",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "MCP server for Zitadel identity management — manage users, projects, apps, roles, and service accounts",
   "type": "module",
   "main": "build/index.js",

--- a/src/__tests__/sso-rbac.test.ts
+++ b/src/__tests__/sso-rbac.test.ts
@@ -1,0 +1,357 @@
+/**
+ * Tests for the SSO/RBAC additions: two-role vocabulary, v2 authorization writes,
+ * org-manager tools, and the atomic provision_user / offboard_user flows.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { HandlerContext } from '../types/tools.js';
+import type { ZitadelConfig } from '../utils/config.js';
+import { isRbacRoleSet, nonStandardRoles, RBAC_PROJECT_ROLES } from '../utils/rbac.js';
+import { ROLE_HANDLERS } from '../tools/roles.js';
+import { ORG_MEMBER_HANDLERS } from '../tools/org-members.js';
+import { PROVISIONING_HANDLERS } from '../tools/provisioning.js';
+
+const PROJECT = 'proj-001';
+const ORG = 'org-789';
+
+type Dispatch = (path: string, method: string, body: any) => any;
+
+function ctxWith(dispatch: Dispatch): HandlerContext {
+  const config = {
+    issuer: 'https://test.zitadel.cloud',
+    serviceAccountUserId: 'sa-123',
+    serviceAccountKeyId: 'key-456',
+    serviceAccountPrivateKey: 'dGVzdA==',
+    orgId: ORG,
+    projectId: PROJECT,
+    logLevel: 'ERROR',
+  } as ZitadelConfig;
+
+  const request = vi.fn((path: string, opts: any = {}) => {
+    const method = opts.method || 'GET';
+    const body = opts.body ? JSON.parse(opts.body) : undefined;
+    try {
+      return Promise.resolve(dispatch(path, method, body));
+    } catch (e) {
+      return Promise.reject(e); // mirror the real client (rejected promise, not sync throw)
+    }
+  });
+
+  const client = { request, getConfig: () => config, clearTokenCache: vi.fn() };
+  return { client: client as any, config };
+}
+
+// Convenience matchers
+const isRoleSearch = (p: string) => p.includes('/roles/_search') && p.includes('/projects/');
+const isGrantSearch = (p: string) => p === '/management/v1/users/grants/_search';
+const isMemberSearch = (p: string) => p === '/management/v1/orgs/me/members/_search';
+
+// ─── rbac vocabulary ──────────────────────────────────────────────────────────
+
+describe('rbac vocabulary', () => {
+  it('RBAC_PROJECT_ROLES is exactly admin + standard', () => {
+    expect([...RBAC_PROJECT_ROLES]).toEqual(['admin', 'standard']);
+  });
+  it('isRbacRoleSet accepts admin/standard, rejects app:* drift', () => {
+    expect(isRbacRoleSet(['admin'])).toBe(true);
+    expect(isRbacRoleSet(['standard'])).toBe(true);
+    expect(isRbacRoleSet(['admin', 'app:finance'])).toBe(false);
+  });
+  it('nonStandardRoles surfaces drift keys', () => {
+    expect(nonStandardRoles(['admin', 'app:finance', 'standard'])).toEqual(['app:finance']);
+  });
+});
+
+// ─── roles: v2 authorization write + drift warning ────────────────────────────
+
+describe('zitadel_create_user_grant (v2 authorization)', () => {
+  it('writes via POST /v2/authorizations and returns the authorization id', async () => {
+    const ctx = ctxWith((path, _m, _b) => {
+      if (isRoleSearch(path)) return { result: [{ key: 'admin' }, { key: 'standard' }] };
+      if (path === '/v2/authorizations') return { id: 'auth-99' };
+      throw new Error(`unmocked ${path}`);
+    });
+    const res = await ROLE_HANDLERS['zitadel_create_user_grant']!({ userId: 'u1', roleKeys: ['admin'] }, ctx);
+    expect(res.isError).toBeFalsy();
+    expect(res.content[0]!.text).toContain('auth-99');
+    const calls = (ctx.client.request as any).mock.calls.map((c: any[]) => c[0]);
+    expect(calls).toContain('/v2/authorizations');
+  });
+
+  it('falls back to v1 user grants when v2 /v2/authorizations is 404', async () => {
+    const ctx = ctxWith((path, method) => {
+      if (isRoleSearch(path)) return { result: [{ key: 'admin' }, { key: 'standard' }] };
+      if (path === '/v2/authorizations') throw Object.assign(new Error('not found'), { status: 404 });
+      if (path === '/management/v1/users/u1/grants' && method === 'POST') return { userGrantId: 'grant-v1' };
+      throw new Error(`unmocked ${path}`);
+    });
+    const res = await ROLE_HANDLERS['zitadel_create_user_grant']!({ userId: 'u1', roleKeys: ['standard'] }, ctx);
+    expect(res.isError).toBeFalsy();
+    expect(res.content[0]!.text).toContain('grant-v1');
+    const calls = (ctx.client.request as any).mock.calls.map((c: any[]) => c[0]);
+    expect(calls).toContain('/v2/authorizations'); // tried v2 first
+    expect(calls).toContain('/management/v1/users/u1/grants'); // then fell back to v1
+  });
+
+  it('flags drift when granting a non-standard role key', async () => {
+    const ctx = ctxWith((path) => {
+      if (isRoleSearch(path)) return { result: [{ key: 'admin' }, { key: 'app:finance' }] };
+      if (path === '/v2/authorizations') return { id: 'auth-1' };
+      throw new Error(`unmocked ${path}`);
+    });
+    const res = await ROLE_HANDLERS['zitadel_create_user_grant']!({ userId: 'u1', roleKeys: ['app:finance'] }, ctx);
+    expect(res.content[0]!.text).toContain('Drift');
+    expect(res.content[0]!.text).toContain('app:finance');
+  });
+});
+
+// ─── org-members ──────────────────────────────────────────────────────────────
+
+describe('zitadel_grant_org_manager', () => {
+  it('adds a new member with default ORG_USER_MANAGER', async () => {
+    const ctx = ctxWith((path, method) => {
+      if (isMemberSearch(path)) return { result: [] }; // not a member yet
+      if (path === '/management/v1/orgs/me/members' && method === 'POST') return { details: {} };
+      throw new Error(`unmocked ${path} ${method}`);
+    });
+    const res = await ORG_MEMBER_HANDLERS['zitadel_grant_org_manager']!({ userId: 'u1' }, ctx);
+    expect(res.content[0]!.text).toContain('ORG_USER_MANAGER');
+    const addCall = (ctx.client.request as any).mock.calls.find((c: any[]) => c[0] === '/management/v1/orgs/me/members');
+    expect(JSON.parse(addCall[1].body)).toEqual({ userId: 'u1', roles: ['ORG_USER_MANAGER'] });
+  });
+
+  it('is idempotent: no change when the role is already held', async () => {
+    const ctx = ctxWith((path) => {
+      if (isMemberSearch(path)) return { result: [{ userId: 'u1', roles: ['ORG_USER_MANAGER'] }] };
+      throw new Error(`unmocked ${path}`);
+    });
+    const res = await ORG_MEMBER_HANDLERS['zitadel_grant_org_manager']!({ userId: 'u1' }, ctx);
+    expect(res.content[0]!.text).toContain('No change');
+    // Only the search should run — no AddOrgMember (POST .../members) and no UpdateOrgMember (PUT).
+    const mutations = (ctx.client.request as any).mock.calls.filter(
+      (c: any[]) => c[0] === '/management/v1/orgs/me/members' || c[1]?.method === 'PUT'
+    );
+    expect(mutations.length).toBe(0);
+  });
+
+  it('merges roles via PUT for an existing member', async () => {
+    const ctx = ctxWith((path, method) => {
+      if (isMemberSearch(path)) return { result: [{ userId: 'u1', roles: ['ORG_USER_MANAGER'] }] };
+      if (path === '/management/v1/orgs/me/members/u1' && method === 'PUT') return {};
+      throw new Error(`unmocked ${path} ${method}`);
+    });
+    const res = await ORG_MEMBER_HANDLERS['zitadel_grant_org_manager']!({ userId: 'u1', roles: ['ORG_OWNER'] }, ctx);
+    const putCall = (ctx.client.request as any).mock.calls.find((c: any[]) => c[1]?.method === 'PUT');
+    expect(JSON.parse(putCall[1].body).roles).toEqual(expect.arrayContaining(['ORG_USER_MANAGER', 'ORG_OWNER']));
+    expect(res.content[0]!.text).toContain('ORG_OWNER');
+  });
+});
+
+describe('zitadel_revoke_org_manager', () => {
+  it('blocks removing the last ORG_OWNER', async () => {
+    const ctx = ctxWith((path, _m, body) => {
+      if (isMemberSearch(path)) {
+        // getOrgMember(u1) -> filtered by userId; owners list -> all owners
+        const byUser = body?.queries?.some((q: any) => q.userIdQuery);
+        if (byUser) return { result: [{ userId: 'u1', roles: ['ORG_OWNER'] }] };
+        return { result: [{ userId: 'u1', roles: ['ORG_OWNER'] }] }; // only one owner
+      }
+      throw new Error(`unmocked ${path}`);
+    });
+    const res = await ORG_MEMBER_HANDLERS['zitadel_revoke_org_manager']!({ userId: 'u1', confirm: true }, ctx);
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toContain('last ORG_OWNER');
+    // No DELETE should have happened
+    const deletes = (ctx.client.request as any).mock.calls.filter((c: any[]) => c[1]?.method === 'DELETE');
+    expect(deletes.length).toBe(0);
+  });
+
+  it('previews without confirm', async () => {
+    const ctx = ctxWith((path) => {
+      if (isMemberSearch(path)) return { result: [{ userId: 'u1', roles: ['ORG_USER_MANAGER'] }] };
+      throw new Error(`unmocked ${path}`);
+    });
+    const res = await ORG_MEMBER_HANDLERS['zitadel_revoke_org_manager']!({ userId: 'u1' }, ctx);
+    expect(res.content[0]!.text).toContain('CONFIRM');
+  });
+
+  it('removes membership with confirm when more than one owner exists', async () => {
+    const ctx = ctxWith((path, method, body) => {
+      if (isMemberSearch(path)) {
+        const byUser = body?.queries?.some((q: any) => q.userIdQuery);
+        if (byUser) return { result: [{ userId: 'u1', roles: ['ORG_USER_MANAGER'] }] };
+        return { result: [{ userId: 'owner-a', roles: ['ORG_OWNER'] }, { userId: 'owner-b', roles: ['ORG_OWNER'] }] };
+      }
+      if (path === '/management/v1/orgs/me/members/u1' && method === 'DELETE') return {};
+      throw new Error(`unmocked ${path} ${method}`);
+    });
+    const res = await ORG_MEMBER_HANDLERS['zitadel_revoke_org_manager']!({ userId: 'u1', confirm: true }, ctx);
+    expect(res.content[0]!.text).toContain('Removed org manager membership');
+  });
+});
+
+// ─── provision_user ───────────────────────────────────────────────────────────
+
+describe('zitadel_provision_user', () => {
+  it('errors when the requested role is not defined in the project', async () => {
+    const ctx = ctxWith((path) => {
+      if (isRoleSearch(path)) return { result: [{ key: 'admin' }] }; // no 'standard'
+      throw new Error(`unmocked ${path}`);
+    });
+    const res = await PROVISIONING_HANDLERS['zitadel_provision_user']!(
+      { email: 'a@b.com', firstName: 'A', lastName: 'B', role: 'standard' },
+      ctx
+    );
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toContain('not defined in project');
+  });
+
+  it('rejects a role outside the two-role vocabulary at the schema level', async () => {
+    const ctx = ctxWith(() => ({}));
+    await expect(
+      PROVISIONING_HANDLERS['zitadel_provision_user']!(
+        { email: 'a@b.com', firstName: 'A', lastName: 'B', role: 'app:finance' },
+        ctx
+      )
+    ).rejects.toThrow();
+  });
+
+  it('creates user + standard role (no manager) and returns structured result', async () => {
+    const ctx = ctxWith((path, method) => {
+      if (isRoleSearch(path)) return { result: [{ key: 'admin' }, { key: 'standard' }] };
+      if (path === '/v2/users' && method === 'POST') return { result: [] }; // findUserByEmail: none
+      if (path === '/v2/users/human' && method === 'POST') return { userId: 'newU' };
+      if (isGrantSearch(path)) return { result: [] };
+      if (path === '/v2/authorizations' && method === 'POST') return { id: 'auth-new' };
+      throw new Error(`unmocked ${path} ${method}`);
+    });
+    const res = await PROVISIONING_HANDLERS['zitadel_provision_user']!(
+      { email: 'a@b.com', firstName: 'A', lastName: 'B', role: 'standard' },
+      ctx
+    );
+    const text = res.content[0]!.text;
+    expect(text).toContain('"zitadelUserId": "newU"');
+    expect(text).toContain('"role": "standard"');
+    expect(text).toContain('"authorizationId": "auth-new"');
+    // standard role must NOT trigger an org-manager add
+    const memberPosts = (ctx.client.request as any).mock.calls.filter(
+      (c: any[]) => c[0] === '/management/v1/orgs/me/members'
+    );
+    expect(memberPosts.length).toBe(0);
+  });
+
+  it('admin role also grants ORG_USER_MANAGER by default', async () => {
+    const ctx = ctxWith((path, method) => {
+      if (isRoleSearch(path)) return { result: [{ key: 'admin' }, { key: 'standard' }] };
+      if (path === '/v2/users' && method === 'POST') return { result: [] };
+      if (path === '/v2/users/human' && method === 'POST') return { userId: 'adminU' };
+      if (isGrantSearch(path)) return { result: [] };
+      if (path === '/v2/authorizations' && method === 'POST') return { id: 'auth-admin' };
+      if (isMemberSearch(path)) return { result: [] };
+      if (path === '/management/v1/orgs/me/members' && method === 'POST') return { details: {} };
+      throw new Error(`unmocked ${path} ${method}`);
+    });
+    const res = await PROVISIONING_HANDLERS['zitadel_provision_user']!(
+      { email: 'admin@b.com', firstName: 'Ad', lastName: 'Min', role: 'admin' },
+      ctx
+    );
+    expect(res.content[0]!.text).toContain('ORG_USER_MANAGER');
+    const addCall = (ctx.client.request as any).mock.calls.find((c: any[]) => c[0] === '/management/v1/orgs/me/members');
+    expect(JSON.parse(addCall[1].body).roles).toEqual(['ORG_USER_MANAGER']);
+  });
+
+  it('is idempotent: reuses an existing user + existing role + existing manager grant', async () => {
+    const ctx = ctxWith((path, method, body) => {
+      if (isRoleSearch(path)) return { result: [{ key: 'admin' }, { key: 'standard' }] };
+      if (path === '/v2/users' && method === 'POST')
+        return { result: [{ userId: 'U1', human: { email: { email: 'admin@b.com' } } }] };
+      if (isGrantSearch(path))
+        return { result: [{ id: 'g1', userId: 'U1', projectId: PROJECT, roleKeys: ['admin'], state: 'USER_GRANT_STATE_ACTIVE' }] };
+      if (isMemberSearch(path)) return { result: [{ userId: 'U1', roles: ['ORG_USER_MANAGER'] }] };
+      throw new Error(`unmocked ${path} ${method} ${JSON.stringify(body)}`);
+    });
+    const res = await PROVISIONING_HANDLERS['zitadel_provision_user']!(
+      { email: 'admin@b.com', firstName: 'Ad', lastName: 'Min', role: 'admin' },
+      ctx
+    );
+    const text = res.content[0]!.text;
+    expect(text).toContain('"createdUser": false');
+    expect(text).toContain('"createdAuthorization": false');
+    expect(text).toContain('"authorizationId": "g1"');
+    // No create-user, no authorization, no member POST should occur
+    const calls = (ctx.client.request as any).mock.calls.map((c: any[]) => `${c[1]?.method || 'GET'} ${c[0]}`);
+    expect(calls).not.toContain('POST /v2/users/human');
+    expect(calls).not.toContain('POST /v2/authorizations');
+    expect(calls).not.toContain('POST /management/v1/orgs/me/members');
+  });
+});
+
+// ─── offboard_user ────────────────────────────────────────────────────────────
+
+describe('zitadel_offboard_user', () => {
+  it('blocks self-demotion', async () => {
+    const ctx = ctxWith((path) => {
+      if (path === '/v2/users/U1') return { user: { userId: 'U1', username: 'u', human: { profile: { givenName: 'A', familyName: 'B' } } } };
+      throw new Error(`unmocked ${path}`);
+    });
+    const res = await PROVISIONING_HANDLERS['zitadel_offboard_user']!(
+      { userId: 'U1', actingUserId: 'U1', confirm: true },
+      ctx
+    );
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toContain('self-offboard');
+  });
+
+  it('blocks removing the last Admin', async () => {
+    const ctx = ctxWith((path, _m, body) => {
+      if (path === '/v2/users/U1') return { user: { userId: 'U1', username: 'u', human: { profile: { givenName: 'A', familyName: 'B' } } } };
+      if (isGrantSearch(path)) {
+        const byRole = body?.queries?.some((q: any) => q.roleKeyQuery);
+        if (byRole) return { result: [{ id: 'g1', userId: 'U1', roleKeys: ['admin'], state: 'USER_GRANT_STATE_ACTIVE' }] }; // only U1
+        return { result: [{ id: 'g1', userId: 'U1', projectId: PROJECT, roleKeys: ['admin'], state: 'USER_GRANT_STATE_ACTIVE' }] };
+      }
+      if (isMemberSearch(path)) return { result: [] };
+      throw new Error(`unmocked ${path}`);
+    });
+    const res = await PROVISIONING_HANDLERS['zitadel_offboard_user']!({ userId: 'U1', confirm: true }, ctx);
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toContain('last Admin');
+  });
+
+  it('previews actions without confirm', async () => {
+    const ctx = ctxWith((path, _m, body) => {
+      if (path === '/v2/users/U2') return { user: { userId: 'U2', username: 'u2', human: { profile: { givenName: 'C', familyName: 'D' } } } };
+      if (isGrantSearch(path)) {
+        const byRole = body?.queries?.some((q: any) => q.roleKeyQuery);
+        if (byRole) return { result: [{ userId: 'U2' }, { userId: 'other' }] };
+        return { result: [{ id: 'g2', userId: 'U2', projectId: PROJECT, roleKeys: ['standard'], state: 'USER_GRANT_STATE_ACTIVE' }] };
+      }
+      if (isMemberSearch(path)) return { result: [] };
+      throw new Error(`unmocked ${path}`);
+    });
+    const res = await PROVISIONING_HANDLERS['zitadel_offboard_user']!({ userId: 'U2' }, ctx);
+    expect(res.content[0]!.text).toContain('CONFIRM');
+    expect(res.content[0]!.text).toContain('deactivate');
+  });
+
+  it('executes: removes grant and deactivates with confirm', async () => {
+    const calls: string[] = [];
+    const ctx = ctxWith((path, method, body) => {
+      calls.push(`${method} ${path}`);
+      if (path === '/v2/users/U2') return { user: { userId: 'U2', username: 'u2', human: { profile: { givenName: 'C', familyName: 'D' } } } };
+      if (isGrantSearch(path)) {
+        const byRole = body?.queries?.some((q: any) => q.roleKeyQuery);
+        if (byRole) return { result: [{ userId: 'U2' }, { userId: 'other' }] };
+        return { result: [{ id: 'g2', userId: 'U2', projectId: PROJECT, roleKeys: ['standard'], state: 'USER_GRANT_STATE_ACTIVE' }] };
+      }
+      if (isMemberSearch(path)) return { result: [] }; // not a manager
+      if (path === '/management/v1/users/U2/grants/g2' && method === 'DELETE') return {};
+      if (path === '/v2/users/U2/deactivate' && method === 'POST') return {};
+      throw new Error(`unmocked ${path} ${method}`);
+    });
+    const res = await PROVISIONING_HANDLERS['zitadel_offboard_user']!({ userId: 'U2', confirm: true }, ctx);
+    expect(res.content[0]!.text).toContain('offboarded');
+    expect(calls).toContain('DELETE /management/v1/users/U2/grants/g2');
+    expect(calls).toContain('POST /v2/users/U2/deactivate');
+  });
+});

--- a/src/__tests__/tools-registry.test.ts
+++ b/src/__tests__/tools-registry.test.ts
@@ -9,6 +9,8 @@ import { APPLICATION_TOOLS, APPLICATION_HANDLERS } from '../tools/applications.j
 import { ROLE_TOOLS, ROLE_HANDLERS } from '../tools/roles.js';
 import { SERVICE_ACCOUNT_TOOLS, SERVICE_ACCOUNT_HANDLERS } from '../tools/service-accounts.js';
 import { ORG_TOOLS, ORG_HANDLERS } from '../tools/organizations.js';
+import { ORG_MEMBER_TOOLS, ORG_MEMBER_HANDLERS } from '../tools/org-members.js';
+import { PROVISIONING_TOOLS, PROVISIONING_HANDLERS } from '../tools/provisioning.js';
 import { UTILITY_TOOLS, UTILITY_HANDLERS } from '../tools/utility.js';
 import { PORTAL_TOOLS, PORTAL_HANDLERS } from '../tools/portal.js';
 import type { ToolDefinition } from '../types/tools.js';
@@ -20,16 +22,19 @@ const ALL_MODULES = [
   { name: 'roles', tools: ROLE_TOOLS, handlers: ROLE_HANDLERS },
   { name: 'service-accounts', tools: SERVICE_ACCOUNT_TOOLS, handlers: SERVICE_ACCOUNT_HANDLERS },
   { name: 'organizations', tools: ORG_TOOLS, handlers: ORG_HANDLERS },
+  { name: 'org-members', tools: ORG_MEMBER_TOOLS, handlers: ORG_MEMBER_HANDLERS },
+  { name: 'provisioning', tools: PROVISIONING_TOOLS, handlers: PROVISIONING_HANDLERS },
   { name: 'utility', tools: UTILITY_TOOLS, handlers: UTILITY_HANDLERS },
   { name: 'portal', tools: PORTAL_TOOLS, handlers: PORTAL_HANDLERS },
 ];
 
 describe('tool registry', () => {
-  it('has 27 total tools', () => {
-    // 8 user + 3 project + 4 application + 5 role + 3 service-account + 1 org + 1 utility + 2 portal = 27
+  it('has 33 total tools', () => {
+    // 8 user + 3 project + 4 application + 5 role + 3 service-account + 1 org
+    // + 4 org-member + 2 provisioning + 1 utility + 2 portal = 33
     // (zitadel_list_orgs removed in REM-22 — uses Admin API, violates least-privilege)
     const total = ALL_MODULES.reduce((sum, m) => sum + m.tools.length, 0);
-    expect(total).toBe(27);
+    expect(total).toBe(33);
   });
 
   it('has no duplicate tool names', () => {

--- a/src/auth/client.ts
+++ b/src/auth/client.ts
@@ -168,18 +168,26 @@ export class ZitadelClient {
         this.clearTokenCache();
       }
 
-      // Return generic message — don't leak Zitadel API internals
+      // Return generic message — don't leak Zitadel API internals.
+      // The numeric status is attached (err.status) so callers can branch on it
+      // (e.g. 404 → fall back to a v1 endpoint, 403 → degrade gracefully) without
+      // parsing the message string. The status itself is not sensitive.
       const status = response.status;
+      let message: string;
       if (status === 404) {
-        throw new Error('The requested resource was not found.');
+        message = 'The requested resource was not found.';
+      } else if (status === 403) {
+        message = 'Permission denied for this operation.';
+      } else if (status === 409) {
+        message = 'A conflict occurred — the resource may already exist.';
+      } else if (status === 429) {
+        message = 'Rate limit exceeded. Please try again later.';
+      } else {
+        message = `Operation failed (HTTP ${status}). Check server logs for details.`;
       }
-      if (status === 409) {
-        throw new Error('A conflict occurred — the resource may already exist.');
-      }
-      if (status === 429) {
-        throw new Error('Rate limit exceeded. Please try again later.');
-      }
-      throw new Error(`Operation failed (HTTP ${status}). Check server logs for details.`);
+      const err = new Error(message) as Error & { status?: number };
+      err.status = status;
+      throw err;
     }
 
     // Handle empty responses (e.g. DELETE operations)

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,15 @@
  * Manage users, projects, apps, roles, and service accounts via the Model Context Protocol
  */
 
-import 'dotenv/config';
+import { config as loadDotenv } from 'dotenv';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+// Load .env from the repo root (one level up from build/ or src/) so secrets can
+// live in a gitignored .env regardless of the process working directory. Existing
+// process env vars take precedence (override: false), so an inline MCP `env` block
+// still wins during migration.
+loadDotenv({ path: join(dirname(fileURLToPath(import.meta.url)), '..', '.env') });
+
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { ListToolsRequestSchema, CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
@@ -30,7 +38,7 @@ async function main() {
   const handlers = getHandlers(config);
 
   const server = new Server(
-    { name: 'zitadel-mcp-server', version: '1.0.0' },
+    { name: 'zitadel-mcp-server', version: '1.1.0' },
     { capabilities: { tools: {} } }
   );
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -9,6 +9,8 @@ import { APPLICATION_TOOLS, APPLICATION_HANDLERS } from './applications.js';
 import { ROLE_TOOLS, ROLE_HANDLERS } from './roles.js';
 import { SERVICE_ACCOUNT_TOOLS, SERVICE_ACCOUNT_HANDLERS } from './service-accounts.js';
 import { ORG_TOOLS, ORG_HANDLERS } from './organizations.js';
+import { ORG_MEMBER_TOOLS, ORG_MEMBER_HANDLERS } from './org-members.js';
+import { PROVISIONING_TOOLS, PROVISIONING_HANDLERS } from './provisioning.js';
 import { UTILITY_TOOLS, UTILITY_HANDLERS } from './utility.js';
 import { PORTAL_TOOLS, PORTAL_HANDLERS } from './portal.js';
 import type { ToolDefinition, ToolHandler } from '../types/tools.js';
@@ -23,6 +25,8 @@ export function getTools(config: ZitadelConfig): ToolDefinition[] {
     ...ROLE_TOOLS,
     ...SERVICE_ACCOUNT_TOOLS,
     ...ORG_TOOLS,
+    ...ORG_MEMBER_TOOLS,
+    ...PROVISIONING_TOOLS,
     ...UTILITY_TOOLS,
   ];
 
@@ -41,6 +45,8 @@ export function getHandlers(config: ZitadelConfig): Record<string, ToolHandler> 
     ...ROLE_HANDLERS,
     ...SERVICE_ACCOUNT_HANDLERS,
     ...ORG_HANDLERS,
+    ...ORG_MEMBER_HANDLERS,
+    ...PROVISIONING_HANDLERS,
     ...UTILITY_HANDLERS,
   };
 

--- a/src/tools/org-members.ts
+++ b/src/tools/org-members.ts
@@ -1,0 +1,268 @@
+/**
+ * Org member (manager / administrator) tools (4 tools)
+ *
+ * Manager roles (ORG_OWNER, ORG_USER_MANAGER, …) administer Zitadel itself and
+ * are DISTINCT from project (business) roles — they do NOT appear in the OIDC
+ * token (zitadel-background.md §7). These are the missing tools the no-super-admin
+ * pattern needs: every Admin gets an ORG_USER_MANAGER grant so any Admin can
+ * manage any user — a flat, equal set of administrators with no Super Admin.
+ *
+ * Endpoints: Management API v1 org-member resources.
+ *   ListOrgMemberRoles  POST /management/v1/orgs/members/roles/_search
+ *   ListOrgMembers      POST /management/v1/orgs/me/members/_search
+ *   AddOrgMember        POST /management/v1/orgs/me/members           {userId, roles}
+ *   UpdateOrgMember     PUT  /management/v1/orgs/me/members/{userId}  {roles}
+ *   RemoveOrgMember     DELETE /management/v1/orgs/me/members/{userId}
+ */
+
+import { z } from 'zod';
+import type { ToolDefinition, ToolHandler, HandlerContext } from '../types/tools.js';
+import { textResponse, errorResponse, zitadelId } from '../types/tools.js';
+import type { ListOrgMembersResponse, ListOrgMemberRolesResponse, OrgMember } from '../types/zitadel.js';
+import { ORG_MANAGER_ROLES, ORG_OWNER_ROLE, DEFAULT_ADMIN_MANAGER_ROLE } from '../utils/rbac.js';
+import { logger } from '../utils/logger.js';
+
+// ─── Tool Definitions ───────────────────────────────────────────────────────
+
+export const ORG_MEMBER_TOOLS: ToolDefinition[] = [
+  {
+    name: 'zitadel_list_org_manager_roles',
+    description: 'List the org-level manager (administrator) role keys this Zitadel org supports (e.g. ORG_OWNER, ORG_USER_MANAGER, ORG_USER_PERMISSION_EDITOR). Use to confirm the exact keys before granting.',
+    inputSchema: { type: 'object', properties: {} },
+    _meta: { readOnly: true, domain: 'organizations' },
+    annotations: { title: 'List Org Manager Roles', readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+  },
+  {
+    name: 'zitadel_list_org_managers',
+    description: 'List users who hold org-level manager (administrator) grants, with their manager roles. Optionally filter to a single role key (e.g. ORG_OWNER) to see who holds it.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        role: { type: 'string', description: 'Optional manager role key to filter by (e.g. "ORG_OWNER", "ORG_USER_MANAGER")' },
+      },
+    },
+    _meta: { readOnly: true, domain: 'organizations' },
+    annotations: { title: 'List Org Managers', readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+  },
+  {
+    name: 'zitadel_grant_org_manager',
+    description: 'Grant org-level manager (administrator) role(s) to a user. For the no-super-admin pattern, grant ORG_USER_MANAGER to every Admin so they can manage any user. Idempotent: merges with any existing manager roles. Defaults to ["ORG_USER_MANAGER"].',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        userId: { type: 'string', description: 'The Zitadel user ID to grant manager role(s) to' },
+        roles: {
+          type: 'array',
+          items: { type: 'string', enum: [...ORG_MANAGER_ROLES] },
+          description: 'Manager role keys. Default ["ORG_USER_MANAGER"] (least-privilege). ORG_OWNER = full org control.',
+        },
+      },
+      required: ['userId'],
+    },
+    _meta: { readOnly: false, domain: 'organizations' },
+    annotations: { title: 'Grant Org Manager', readOnlyHint: false, destructiveHint: false, idempotentHint: true },
+  },
+  {
+    name: 'zitadel_revoke_org_manager',
+    description: 'Revoke org-level manager role(s) from a user. Omit roles to remove the entire manager membership. Guards against removing the last ORG_OWNER. Requires confirm: true.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        userId: { type: 'string', description: 'The Zitadel user ID to revoke manager role(s) from' },
+        roles: {
+          type: 'array',
+          items: { type: 'string', enum: [...ORG_MANAGER_ROLES] },
+          description: 'Specific manager role keys to remove. Omit to remove all of the user\'s manager roles.',
+        },
+        confirm: { type: 'boolean', description: 'Must be true to execute. Omit to preview the action.' },
+      },
+      required: ['userId'],
+    },
+    _meta: { readOnly: false, domain: 'organizations' },
+    annotations: { title: 'Revoke Org Manager', readOnlyHint: false, destructiveHint: true, idempotentHint: true },
+  },
+];
+
+// ─── Shared helpers (exported for provisioning tools) ────────────────────────
+
+export async function listOrgManagers(
+  ctx: HandlerContext,
+  opts?: { userId?: string; role?: string }
+): Promise<OrgMember[]> {
+  const queries: unknown[] = [];
+  if (opts?.userId) queries.push({ userIdQuery: { userId: opts.userId } });
+  const resp = await ctx.client.request<ListOrgMembersResponse>(
+    '/management/v1/orgs/me/members/_search',
+    {
+      method: 'POST',
+      body: JSON.stringify({ query: { offset: '0', limit: '500' }, ...(queries.length ? { queries } : {}) }),
+    }
+  );
+  let members = resp.result || [];
+  if (opts?.role) members = members.filter((m) => (m.roles || []).includes(opts.role!));
+  return members;
+}
+
+export async function getOrgMember(ctx: HandlerContext, userId: string): Promise<OrgMember | null> {
+  const members = await listOrgManagers(ctx, { userId });
+  return members.find((m) => m.userId === userId) || null;
+}
+
+/** Idempotently add manager roles; merges with any existing membership. */
+export async function addOrgManager(
+  ctx: HandlerContext,
+  userId: string,
+  roles: string[]
+): Promise<{ changed: boolean; roles: string[] }> {
+  const existing = await getOrgMember(ctx, userId);
+  if (existing) {
+    const union = Array.from(new Set([...(existing.roles || []), ...roles]));
+    if (union.length === (existing.roles || []).length) {
+      return { changed: false, roles: existing.roles || [] };
+    }
+    await ctx.client.request(`/management/v1/orgs/me/members/${userId}`, {
+      method: 'PUT',
+      body: JSON.stringify({ roles: union }),
+    });
+    return { changed: true, roles: union };
+  }
+  await ctx.client.request('/management/v1/orgs/me/members', {
+    method: 'POST',
+    body: JSON.stringify({ userId, roles }),
+  });
+  return { changed: true, roles };
+}
+
+/**
+ * Guard: returns an error string if removing `rolesBeingRemoved` from `userId`
+ * would drop the org's last ORG_OWNER. Pass empty/undefined rolesBeingRemoved to
+ * mean "remove the whole membership". Returns null when the removal is safe.
+ */
+export async function guardLastOwner(
+  ctx: HandlerContext,
+  userId: string,
+  rolesBeingRemoved?: string[]
+): Promise<string | null> {
+  const removesOwner = !rolesBeingRemoved || rolesBeingRemoved.length === 0 || rolesBeingRemoved.includes(ORG_OWNER_ROLE);
+  if (!removesOwner) return null;
+  const owners = await listOrgManagers(ctx, { role: ORG_OWNER_ROLE });
+  const targetIsOwner = owners.some((o) => o.userId === userId);
+  if (!targetIsOwner) return null;
+  if (owners.length <= 1) {
+    return (
+      `Refusing to remove the last ORG_OWNER (user ${userId}). Zitadel does not document a built-in ` +
+      `last-owner guard — keep ≥2 ORG_OWNER break-glass accounts (zitadel-background.md §7).`
+    );
+  }
+  return null;
+}
+
+/** Remove specific manager roles (or the whole membership). Caller must run guardLastOwner first. */
+export async function removeOrgManager(
+  ctx: HandlerContext,
+  userId: string,
+  roles?: string[]
+): Promise<{ removedMember: boolean; remainingRoles: string[] }> {
+  const existing = await getOrgMember(ctx, userId);
+  if (!existing) return { removedMember: false, remainingRoles: [] };
+  const toRemove = roles && roles.length ? roles : existing.roles || [];
+  const remaining = (existing.roles || []).filter((r) => !toRemove.includes(r));
+  if (remaining.length === 0) {
+    await ctx.client.request(`/management/v1/orgs/me/members/${userId}`, { method: 'DELETE' });
+    return { removedMember: true, remainingRoles: [] };
+  }
+  await ctx.client.request(`/management/v1/orgs/me/members/${userId}`, {
+    method: 'PUT',
+    body: JSON.stringify({ roles: remaining }),
+  });
+  return { removedMember: false, remainingRoles: remaining };
+}
+
+function formatMember(m: OrgMember): string {
+  const who = m.preferredLoginName || m.displayName || m.userId;
+  return `- ${who} (${m.userId}): [${(m.roles || []).join(', ')}]`;
+}
+
+// ─── Handlers ────────────────────────────────────────────────────────────────
+
+const listOrgManagerRolesHandler: ToolHandler = async (_params, ctx) => {
+  const resp = await ctx.client.request<ListOrgMemberRolesResponse>(
+    '/management/v1/orgs/members/roles/_search',
+    { method: 'POST', body: '{}' }
+  );
+  const roles = resp.result || [];
+  if (roles.length === 0) return textResponse('No org manager roles returned.');
+  return textResponse(`Org manager roles supported by this org (${roles.length}):\n\n${roles.map((r) => `- ${r}`).join('\n')}`);
+};
+
+const listOrgManagersHandler: ToolHandler = async (params, ctx) => {
+  const { role } = z.object({ role: z.string().max(100).optional() }).parse(params);
+  const members = await listOrgManagers(ctx, role ? { role } : undefined);
+  if (members.length === 0) {
+    return textResponse(role ? `No users hold the manager role "${role}".` : 'No org managers found.');
+  }
+  const header = role ? `Users holding manager role "${role}" (${members.length}):` : `Org managers (${members.length}):`;
+  return textResponse(`${header}\n\n${members.map(formatMember).join('\n')}`);
+};
+
+const grantOrgManagerHandler: ToolHandler = async (params, ctx) => {
+  const input = z.object({
+    userId: zitadelId('userId'),
+    roles: z.array(z.enum(ORG_MANAGER_ROLES)).min(1).max(10).optional(),
+  }).parse(params);
+  const roles = input.roles && input.roles.length ? input.roles : [DEFAULT_ADMIN_MANAGER_ROLE];
+
+  logger.info('Granting org manager role(s)', { userId: input.userId });
+
+  const result = await addOrgManager(ctx, input.userId, roles);
+  if (!result.changed) {
+    return textResponse(`User ${input.userId} already holds manager role(s) [${result.roles.join(', ')}]. No change.`);
+  }
+  return textResponse(
+    `Org manager grant applied.\n` +
+    `User: ${input.userId}\n` +
+    `Manager roles now: [${result.roles.join(', ')}]`
+  );
+};
+
+const revokeOrgManagerHandler: ToolHandler = async (params, ctx) => {
+  const input = z.object({
+    userId: zitadelId('userId'),
+    roles: z.array(z.enum(ORG_MANAGER_ROLES)).max(10).optional(),
+    confirm: z.boolean().optional(),
+  }).parse(params);
+
+  const existing = await getOrgMember(ctx, input.userId);
+  if (!existing) {
+    return textResponse(`User ${input.userId} holds no org manager roles. Nothing to revoke.`);
+  }
+
+  // Last-owner guard (run before mutating).
+  const guard = await guardLastOwner(ctx, input.userId, input.roles);
+  if (guard) return errorResponse(guard);
+
+  if (!input.confirm) {
+    const scope = input.roles && input.roles.length ? `role(s) [${input.roles.join(', ')}]` : `ALL manager roles [${(existing.roles || []).join(', ')}]`;
+    return textResponse(
+      `⚠ CONFIRM: Revoke ${scope} from user ${input.userId}?\n` +
+      `This removes their ability to administer Zitadel (not their app/project access).\n\n` +
+      `To proceed, call zitadel_revoke_org_manager again with confirm: true.`
+    );
+  }
+
+  const result = await removeOrgManager(ctx, input.userId, input.roles);
+  return textResponse(
+    result.removedMember
+      ? `Removed org manager membership entirely from user ${input.userId}.`
+      : `Updated org manager roles for user ${input.userId}. Remaining: [${result.remainingRoles.join(', ')}]`
+  );
+};
+
+// ─── Export ──────────────────────────────────────────────────────────────────
+
+export const ORG_MEMBER_HANDLERS: Record<string, ToolHandler> = {
+  zitadel_list_org_manager_roles: listOrgManagerRolesHandler,
+  zitadel_list_org_managers: listOrgManagersHandler,
+  zitadel_grant_org_manager: grantOrgManagerHandler,
+  zitadel_revoke_org_manager: revokeOrgManagerHandler,
+};

--- a/src/tools/provisioning.ts
+++ b/src/tools/provisioning.ts
@@ -1,0 +1,332 @@
+/**
+ * High-level user provisioning tools (2 tools) — the app-portal cascade-up.
+ *
+ *   zitadel_provision_user  — atomic, idempotent: create human user + assign the
+ *                             Admin|Standard project role (v2 authorization) +
+ *                             (for Admins) grant ORG_USER_MANAGER. Returns
+ *                             { zitadelUserId, role, authorizationId, ... }.
+ *   zitadel_offboard_user   — deactivate + remove role assignment + revoke
+ *                             manager grant, with guards: can't remove the last
+ *                             Admin, can't self-demote, can't remove last owner.
+ *
+ * Background: zitadel-background.md §6 (provisioning cascade) and §7 (no-super-admin,
+ * guardrails). These compose the lower-level user/role/org-member helpers so the
+ * whole flow is one idempotent call.
+ */
+
+import { z } from 'zod';
+import type { ToolDefinition, ToolHandler, HandlerContext } from '../types/tools.js';
+import { textResponse, errorResponse, zitadelId } from '../types/tools.js';
+import type { GetUserResponse, UserGrant, ZitadelUserDetails } from '../types/zitadel.js';
+import {
+  RBAC_PROJECT_ROLES,
+  rbacProjectRoleSchema,
+  DEFAULT_ADMIN_MANAGER_ROLE,
+  ORG_OWNER_ROLE,
+} from '../utils/rbac.js';
+import { findUserByEmail, createHumanUser } from './users.js';
+import {
+  resolveProjectId,
+  getProjectRoleKeys,
+  assignProjectRole,
+  listUserProjectGrants,
+  listRoleHolders,
+  removeProjectGrant,
+} from './roles.js';
+import { addOrgManager, getOrgMember, guardLastOwner, removeOrgManager } from './org-members.js';
+import { logger } from '../utils/logger.js';
+
+// ─── Tool Definitions ───────────────────────────────────────────────────────
+
+export const PROVISIONING_TOOLS: ToolDefinition[] = [
+  {
+    name: 'zitadel_provision_user',
+    description:
+      'Atomically provision a user for the core SSO apps (the app-portal cascade-up). Creates the human user (idempotent by email or supplied userId), assigns the Admin|Standard project role via the v2 AuthorizationService, and — for Admins — grants ORG_USER_MANAGER so they can manage any user (no-super-admin pattern). Returns { zitadelUserId, role, authorizationId }. Safe to re-run.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        email: { type: 'string', description: 'Email address for the user' },
+        firstName: { type: 'string', description: 'First name' },
+        lastName: { type: 'string', description: 'Last name' },
+        role: { type: 'string', enum: [...RBAC_PROJECT_ROLES], description: 'Business role: "admin" or "standard" (the only two)' },
+        userId: { type: 'string', description: 'Optional client-supplied user ID for idempotent retries' },
+        grantOrgManager: {
+          type: 'boolean',
+          description: 'Grant the org-manager role. Default: true for role=admin, false for role=standard. Set explicitly to override.',
+        },
+        projectId: { type: 'string', description: 'Project ID for the role assignment (uses default project if omitted)' },
+      },
+      required: ['email', 'firstName', 'lastName', 'role'],
+    },
+    _meta: { readOnly: false, domain: 'provisioning' },
+    annotations: { title: 'Provision User', readOnlyHint: false, destructiveHint: false, idempotentHint: true },
+  },
+  {
+    name: 'zitadel_offboard_user',
+    description:
+      'Offboard a user: remove their Admin|Standard project role assignment, revoke any org-manager grant, and deactivate the account. Guards: cannot remove the last Admin, cannot self-demote (pass actingUserId), cannot remove the last ORG_OWNER. Requires confirm: true.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        userId: { type: 'string', description: 'The Zitadel user ID to offboard (or provide email)' },
+        email: { type: 'string', description: 'Email of the user to offboard (used if userId omitted)' },
+        actingUserId: { type: 'string', description: 'The user performing the action — blocks self-demotion if it equals the target' },
+        deactivate: { type: 'boolean', description: 'Deactivate the account (default: true)' },
+        removeManager: { type: 'boolean', description: 'Revoke org-manager grant (default: true)' },
+        projectId: { type: 'string', description: 'Project ID (uses default project if omitted)' },
+        confirm: { type: 'boolean', description: 'Must be true to execute. Omit to preview the action.' },
+      },
+    },
+    _meta: { readOnly: false, domain: 'provisioning' },
+    annotations: { title: 'Offboard User', readOnlyHint: false, destructiveHint: true, idempotentHint: true },
+  },
+];
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+async function getUserById(ctx: HandlerContext, userId: string): Promise<ZitadelUserDetails | null> {
+  try {
+    const resp = await ctx.client.request<GetUserResponse>(`/v2/users/${userId}`);
+    return resp.user;
+  } catch {
+    return null;
+  }
+}
+
+/** Active grants for this user on the project whose roleKeys intersect the RBAC vocabulary. */
+function rbacGrants(grants: UserGrant[]): UserGrant[] {
+  return grants.filter(
+    (g) =>
+      g.state !== 'USER_GRANT_STATE_INACTIVE' &&
+      (g.roleKeys || []).some((k) => (RBAC_PROJECT_ROLES as readonly string[]).includes(k))
+  );
+}
+
+// ─── provision_user ───────────────────────────────────────────────────────────
+
+const provisionUserHandler: ToolHandler = async (params, ctx) => {
+  const input = z.object({
+    email: z.string().email().max(320),
+    firstName: z.string().min(1).max(200),
+    lastName: z.string().min(1).max(200),
+    role: rbacProjectRoleSchema,
+    userId: zitadelId('userId').optional(),
+    grantOrgManager: z.boolean().optional(),
+  }).parse(params);
+  const projectId = resolveProjectId(params, ctx);
+
+  // 1. The target project must actually define the requested role.
+  const projectRoles = await getProjectRoleKeys(projectId, ctx);
+  if (!projectRoles.includes(input.role)) {
+    return errorResponse(
+      `Role "${input.role}" is not defined in project ${projectId}. Available: ${projectRoles.join(', ') || 'none'}.\n` +
+      `Create it first with zitadel_create_project_role (roleKey "${input.role}").`
+    );
+  }
+
+  // 2. Resolve or create the user (idempotent by supplied userId, then by email).
+  let user: ZitadelUserDetails | null = null;
+  if (input.userId) user = await getUserById(ctx, input.userId);
+  if (!user) user = await findUserByEmail(ctx, input.email);
+
+  let createdUser = false;
+  let zitadelUserId: string;
+  if (user) {
+    zitadelUserId = user.userId;
+  } else {
+    zitadelUserId = await createHumanUser(ctx, {
+      email: input.email,
+      firstName: input.firstName,
+      lastName: input.lastName,
+      userId: input.userId,
+    });
+    createdUser = true;
+  }
+
+  // 3. Ensure the project-role authorization (idempotent: reuse an existing grant that already has the role).
+  const existingGrants = await listUserProjectGrants(ctx, zitadelUserId, projectId);
+  const already = rbacGrants(existingGrants).find((g) => (g.roleKeys || []).includes(input.role));
+  let authorizationId: string;
+  let createdAuthorization = false;
+  if (already) {
+    authorizationId = already.id;
+  } else {
+    const { id } = await assignProjectRole(ctx, { userId: zitadelUserId, projectId, roleKeys: [input.role] });
+    authorizationId = id;
+    createdAuthorization = true;
+  }
+
+  // Note any pre-existing OTHER rbac role (we don't auto-remove it here — that's a role change / offboard concern).
+  const otherRoles = rbacGrants(existingGrants)
+    .flatMap((g) => g.roleKeys || [])
+    .filter((k) => (RBAC_PROJECT_ROLES as readonly string[]).includes(k) && k !== input.role);
+
+  // 4. Org-manager grant — default true for admins, false for standard.
+  // Granting a manager role requires org-member write (ORG_OWNER); an
+  // ORG_USER_MANAGER service account will get 403 here. Degrade gracefully: the
+  // user + project role are already in place, so report the gap rather than fail.
+  const wantManager = input.grantOrgManager ?? input.role === 'admin';
+  let orgManagerRoles: string[] = [];
+  let managerChanged = false;
+  let managerError: string | null = null;
+  if (wantManager) {
+    try {
+      const result = await addOrgManager(ctx, zitadelUserId, [DEFAULT_ADMIN_MANAGER_ROLE]);
+      orgManagerRoles = result.roles;
+      managerChanged = result.changed;
+    } catch (e) {
+      if ((e as { status?: number }).status === 403) {
+        managerError =
+          `${DEFAULT_ADMIN_MANAGER_ROLE} NOT granted — this service account lacks org-member write ` +
+          `(needs ORG_OWNER). Apply it via an ORG_OWNER credential or the Console so this Admin can manage users.`;
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  logger.info('Provisioned user', { createdUser, createdAuthorization, role: input.role });
+
+  const out = {
+    zitadelUserId,
+    role: input.role,
+    authorizationId,
+    orgManagerRoles,
+    createdUser,
+    createdAuthorization,
+    managerChanged,
+  };
+
+  const notes: string[] = [];
+  if (!createdUser) notes.push(`Reused existing user (${input.email}).`);
+  if (!createdAuthorization) notes.push(`Role "${input.role}" was already assigned.`);
+  if (otherRoles.length) notes.push(`⚠ User also holds other project role(s): ${otherRoles.join(', ')} (not removed).`);
+  if (managerError) notes.push(`⚠ ${managerError}`);
+  else if (wantManager && !managerChanged) notes.push(`Org-manager role already present.`);
+  if (createdUser) notes.push(`An invitation/MFA-enrollment email was sent to ${input.email}.`);
+
+  return textResponse(
+    `User provisioned.\n\n` +
+    JSON.stringify(out, null, 2) +
+    (notes.length ? `\n\n${notes.join('\n')}` : '')
+  );
+};
+
+// ─── offboard_user ────────────────────────────────────────────────────────────
+
+const offboardUserHandler: ToolHandler = async (params, ctx) => {
+  const input = z.object({
+    userId: zitadelId('userId').optional(),
+    email: z.string().email().max(320).optional(),
+    actingUserId: zitadelId('actingUserId').optional(),
+    deactivate: z.boolean().default(true),
+    removeManager: z.boolean().default(true),
+    confirm: z.boolean().optional(),
+  }).parse(params);
+  const projectId = resolveProjectId(params, ctx);
+
+  if (!input.userId && !input.email) {
+    return errorResponse('Provide either userId or email to identify the user to offboard.');
+  }
+
+  // Resolve the target user.
+  let user: ZitadelUserDetails | null = null;
+  if (input.userId) user = await getUserById(ctx, input.userId);
+  if (!user && input.email) user = await findUserByEmail(ctx, input.email);
+  if (!user) return errorResponse(`User not found (${input.userId || input.email}).`);
+  const targetId = user.userId;
+
+  // Guard: self-demotion.
+  if (input.actingUserId && input.actingUserId === targetId) {
+    return errorResponse(`Refusing to self-offboard: actingUserId equals the target (${targetId}). Have another Admin perform this.`);
+  }
+
+  // Inspect current state.
+  const grants = rbacGrants(await listUserProjectGrants(ctx, targetId, projectId));
+  const holdsAdmin = grants.some((g) => (g.roleKeys || []).includes('admin'));
+  // Reading org-member state needs org-member read (ORG_OWNER); an
+  // ORG_USER_MANAGER service account gets 403. Degrade: we can still remove the
+  // project role and deactivate; we just can't see/revoke manager roles.
+  let managerRoles: string[] = [];
+  let managerReadFailed = false;
+  try {
+    const member = await getOrgMember(ctx, targetId);
+    managerRoles = member?.roles || [];
+  } catch (e) {
+    if ((e as { status?: number }).status === 403) managerReadFailed = true;
+    else throw e;
+  }
+
+  // Guard: last Admin.
+  if (holdsAdmin) {
+    const adminHolders = await listRoleHolders(ctx, projectId, 'admin');
+    const otherAdmins = new Set(adminHolders.map((g) => g.userId));
+    otherAdmins.delete(targetId);
+    if (otherAdmins.size === 0) {
+      return errorResponse(
+        `Refusing to offboard the last Admin (user ${targetId}). Promote another user to Admin first ` +
+        `(zitadel_provision_user role=admin) so the org is never left without one.`
+      );
+    }
+  }
+
+  // Guard: last ORG_OWNER (only relevant if we'd remove the manager membership).
+  if (input.removeManager && managerRoles.includes(ORG_OWNER_ROLE)) {
+    const ownerGuard = await guardLastOwner(ctx, targetId, managerRoles);
+    if (ownerGuard) return errorResponse(ownerGuard);
+  }
+
+  // Preview.
+  if (!input.confirm) {
+    const who = user.human?.profile
+      ? `${user.human.profile.givenName} ${user.human.profile.familyName}`.trim()
+      : user.username;
+    const actions: string[] = [];
+    if (grants.length) actions.push(`remove project role grant(s): ${grants.map((g) => (g.roleKeys || []).join('/')).join(', ')}`);
+    if (input.removeManager && managerRoles.length) actions.push(`revoke org-manager role(s): ${managerRoles.join(', ')}`);
+    if (input.removeManager && managerReadFailed) actions.push(`(manager roles could not be read — needs ORG_OWNER; will attempt revoke)`);
+    if (input.deactivate) actions.push(`deactivate the account`);
+    return textResponse(
+      `⚠ CONFIRM: Offboard "${who}" (${targetId})?\n` +
+      (actions.length ? actions.map((a) => `  • ${a}`).join('\n') : '  • (no role/manager grants found)') +
+      `\n\nTo proceed, call zitadel_offboard_user again with confirm: true.`
+    );
+  }
+
+  // Execute.
+  const done: string[] = [];
+  for (const g of grants) {
+    await removeProjectGrant(ctx, targetId, g.id);
+    done.push(`removed grant ${g.id} [${(g.roleKeys || []).join(', ')}]`);
+  }
+  if (input.removeManager && (managerRoles.length || managerReadFailed)) {
+    try {
+      const r = await removeOrgManager(ctx, targetId);
+      if (r.removedMember) done.push(`revoked all org-manager roles`);
+      else if (r.remainingRoles.length) done.push(`reduced org-manager roles to [${r.remainingRoles.join(', ')}]`);
+      else done.push(`no org-manager roles to revoke`);
+    } catch (e) {
+      if ((e as { status?: number }).status === 403) {
+        done.push(`⚠ could not revoke manager roles — service account lacks org-member write (needs ORG_OWNER)`);
+      } else {
+        throw e;
+      }
+    }
+  }
+  if (input.deactivate) {
+    await ctx.client.request(`/v2/users/${targetId}/deactivate`, { method: 'POST' });
+    done.push(`deactivated account`);
+  }
+
+  return textResponse(
+    `User ${targetId} offboarded.\n` + (done.length ? done.map((d) => `  • ${d}`).join('\n') : '  • nothing to do')
+  );
+};
+
+// ─── Export ──────────────────────────────────────────────────────────────────
+
+export const PROVISIONING_HANDLERS: Record<string, ToolHandler> = {
+  zitadel_provision_user: provisionUserHandler,
+  zitadel_offboard_user: offboardUserHandler,
+};

--- a/src/tools/roles.ts
+++ b/src/tools/roles.ts
@@ -1,12 +1,25 @@
 /**
  * Role & grant management tools (5 tools)
- * Project roles and user grants via Zitadel Management API v1
+ *
+ * Project roles via Management API v1. Role assignment (granting a project role
+ * to a user) is written via the v2 AuthorizationService (POST /v2/authorizations,
+ * zitadel-background.md §6) — v1 user-grant endpoints are deprecated. Reads and
+ * removals use the proven v1 grant endpoints; a v2 authorization id is the same
+ * aggregate id as a v1 user grant, so the two interoperate.
  */
 
 import { z } from 'zod';
-import type { ToolDefinition, ToolHandler } from '../types/tools.js';
+import type { ToolDefinition, ToolHandler, HandlerContext } from '../types/tools.js';
 import { textResponse, errorResponse, zitadelId } from '../types/tools.js';
-import type { ListProjectRolesResponse, ListUserGrantsResponse, CreateUserGrantResponse, UserGrant } from '../types/zitadel.js';
+import type {
+  ListProjectRolesResponse,
+  ListUserGrantsResponse,
+  CreateAuthorizationRequest,
+  CreateAuthorizationResponse,
+  CreateUserGrantResponse,
+  UserGrant,
+} from '../types/zitadel.js';
+import { nonStandardRoles, RBAC_PROJECT_ROLES } from '../utils/rbac.js';
 import { logger } from '../utils/logger.js';
 
 // ─── Tool Definitions ───────────────────────────────────────────────────────
@@ -14,7 +27,7 @@ import { logger } from '../utils/logger.js';
 export const ROLE_TOOLS: ToolDefinition[] = [
   {
     name: 'zitadel_list_project_roles',
-    description: 'List all roles defined in a Zitadel project (e.g., "admin", "app:finance").',
+    description: 'List all roles defined in a Zitadel project (e.g., "admin", "standard").',
     inputSchema: {
       type: 'object',
       properties: {
@@ -26,12 +39,12 @@ export const ROLE_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'zitadel_create_project_role',
-    description: 'Create a new role in a Zitadel project. Use key format "app:{slug}" for app-specific access roles.',
+    description: 'Create a new role in a Zitadel project. For the standardized RBAC model use the keys "admin" or "standard" (see zitadel_provision_user).',
     inputSchema: {
       type: 'object',
       properties: {
         projectId: { type: 'string', description: 'The project ID (uses default project if omitted)' },
-        roleKey: { type: 'string', description: 'Role key (e.g., "admin", "app:finance", "app:timesheets")' },
+        roleKey: { type: 'string', description: 'Role key. Standardized vocabulary: "admin" or "standard".' },
         displayName: { type: 'string', description: 'Human-readable role name' },
         group: { type: 'string', description: 'Optional role group for organization' },
       },
@@ -42,7 +55,7 @@ export const ROLE_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'zitadel_list_user_grants',
-    description: 'List role grants for a specific user, showing which roles they have been assigned.',
+    description: 'List role grants (authorizations) for a specific user, showing which project roles they have been assigned.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -56,7 +69,7 @@ export const ROLE_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'zitadel_create_user_grant',
-    description: 'Assign roles to a user by creating a grant. Validates that the roles exist in the project before granting.',
+    description: 'Assign project roles to a user via the v2 AuthorizationService. Validates that the roles exist in the project before granting. For the standardized two-role model prefer "admin"/"standard"; other keys are allowed but flagged as drift.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -64,7 +77,7 @@ export const ROLE_TOOLS: ToolDefinition[] = [
         roleKeys: {
           type: 'array',
           items: { type: 'string' },
-          description: 'Array of role keys to assign (e.g., ["admin", "app:finance"])',
+          description: 'Array of role keys to assign (standardized: ["admin"] or ["standard"])',
         },
         projectId: { type: 'string', description: 'The project ID (uses default project if omitted)' },
       },
@@ -75,12 +88,12 @@ export const ROLE_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'zitadel_remove_user_grant',
-    description: 'Remove a role grant from a user by grant ID. Requires confirm: true.',
+    description: 'Remove a role grant (authorization) from a user by grant ID. Requires confirm: true.',
     inputSchema: {
       type: 'object',
       properties: {
         userId: { type: 'string', description: 'The user ID' },
-        grantId: { type: 'string', description: 'The grant ID to remove' },
+        grantId: { type: 'string', description: 'The grant / authorization ID to remove' },
         confirm: { type: 'boolean', description: 'Must be true to execute. Omit to preview the action.' },
       },
       required: ['userId', 'grantId'],
@@ -90,9 +103,9 @@ export const ROLE_TOOLS: ToolDefinition[] = [
   },
 ];
 
-// ─── Helpers ─────────────────────────────────────────────────────────────────
+// ─── Shared helpers (exported for provisioning tools) ────────────────────────
 
-function resolveProjectId(params: Record<string, unknown>, ctx: { config: { projectId?: string } }): string {
+export function resolveProjectId(params: Record<string, unknown>, ctx: { config: { projectId?: string } }): string {
   const projectId = (params['projectId'] as string) || ctx.config.projectId;
   if (!projectId) {
     throw new Error('projectId is required — either pass it as a parameter or set ZITADEL_PROJECT_ID');
@@ -100,15 +113,101 @@ function resolveProjectId(params: Record<string, unknown>, ctx: { config: { proj
   return projectId;
 }
 
-async function getProjectRoleKeys(projectId: string, ctx: { client: { request: <T>(path: string, options?: RequestInit) => Promise<T> } }): Promise<string[]> {
+/** All role keys defined on a project (used to validate before granting). */
+export async function getProjectRoleKeys(projectId: string, ctx: HandlerContext): Promise<string[]> {
   const response = await ctx.client.request<ListProjectRolesResponse>(
     `/management/v1/projects/${projectId}/roles/_search`,
+    { method: 'POST', body: JSON.stringify({ query: { offset: '0', limit: 100 } }) }
+  );
+  return (response.result || []).map((r) => r.key);
+}
+
+// Per-client cache of whether the v2 AuthorizationService is available on the
+// instance. Some Zitadel Cloud versions do not expose POST /v2/authorizations
+// (it 404s) — we detect that once and fall back to the v1 user-grant endpoint
+// for the rest of the process. Keyed by client so unit tests don't leak state.
+const v2AuthzAvailable = new WeakMap<object, boolean>();
+
+/**
+ * Assign project roles to a user. Prefers the v2 AuthorizationService
+ * (POST /v2/authorizations); if that endpoint is unavailable on the instance
+ * (404), transparently falls back to the proven v1 user-grant endpoint. Returns
+ * the resulting authorization/grant id (the same aggregate id either way), plus
+ * which API path was used.
+ */
+export async function assignProjectRole(
+  ctx: HandlerContext,
+  args: { userId: string; projectId: string; roleKeys: string[]; organizationId?: string }
+): Promise<{ id: string; via: 'v2' | 'v1' }> {
+  const clientKey = ctx.client as unknown as object;
+
+  if (v2AuthzAvailable.get(clientKey) !== false) {
+    try {
+      const body: CreateAuthorizationRequest = {
+        userId: args.userId,
+        projectId: args.projectId,
+        organizationId: args.organizationId ?? ctx.config.orgId,
+        roleKeys: args.roleKeys,
+      };
+      const resp = await ctx.client.request<CreateAuthorizationResponse>('/v2/authorizations', {
+        method: 'POST',
+        body: JSON.stringify(body),
+      });
+      v2AuthzAvailable.set(clientKey, true);
+      return { id: resp.id, via: 'v2' };
+    } catch (e) {
+      const status = (e as { status?: number }).status;
+      if (status !== 404) throw e; // real error (perm/validation) — surface it
+      v2AuthzAvailable.set(clientKey, false);
+      logger.info('v2 /v2/authorizations unavailable (404) — falling back to v1 user grants');
+    }
+  }
+
+  // v1 fallback: POST /management/v1/users/{userId}/grants
+  const resp = await ctx.client.request<CreateUserGrantResponse>(
+    `/management/v1/users/${args.userId}/grants`,
+    { method: 'POST', body: JSON.stringify({ projectId: args.projectId, roleKeys: args.roleKeys }) }
+  );
+  return { id: resp.userGrantId, via: 'v1' };
+}
+
+/** A user's project-role grants (v1 read), optionally filtered to one project. */
+export async function listUserProjectGrants(
+  ctx: HandlerContext,
+  userId: string,
+  projectId?: string
+): Promise<UserGrant[]> {
+  const queries: unknown[] = [{ userIdQuery: { userId } }];
+  if (projectId) queries.push({ projectIdQuery: { projectId } });
+  const resp = await ctx.client.request<ListUserGrantsResponse>(
+    '/management/v1/users/grants/_search',
+    { method: 'POST', body: JSON.stringify({ query: { offset: '0', limit: 100 }, queries }) }
+  );
+  return resp.result || [];
+}
+
+/** Active grants on a project that include a specific role key (last-admin guard). */
+export async function listRoleHolders(
+  ctx: HandlerContext,
+  projectId: string,
+  roleKey: string
+): Promise<UserGrant[]> {
+  const resp = await ctx.client.request<ListUserGrantsResponse>(
+    '/management/v1/users/grants/_search',
     {
       method: 'POST',
-      body: JSON.stringify({ query: { offset: '0', limit: 100 } }),
+      body: JSON.stringify({
+        query: { offset: '0', limit: 500 },
+        queries: [{ projectIdQuery: { projectId } }, { roleKeyQuery: { roleKey } }],
+      }),
     }
   );
-  return (response.result || []).map(r => r.key);
+  return (resp.result || []).filter((g) => g.state !== 'USER_GRANT_STATE_INACTIVE');
+}
+
+/** Remove a project-role grant (authorization) by its id. */
+export async function removeProjectGrant(ctx: HandlerContext, userId: string, grantId: string): Promise<void> {
+  await ctx.client.request(`/management/v1/users/${userId}/grants/${grantId}`, { method: 'DELETE' });
 }
 
 function formatGrant(g: UserGrant): string {
@@ -121,26 +220,20 @@ function formatGrant(g: UserGrant): string {
 
 const listProjectRolesHandler: ToolHandler = async (params, ctx) => {
   const projectId = resolveProjectId(params, ctx);
-
-  const response = await ctx.client.request<ListProjectRolesResponse>(
-    `/management/v1/projects/${projectId}/roles/_search`,
-    {
-      method: 'POST',
-      body: JSON.stringify({ query: { offset: '0', limit: 100 } }),
-    }
-  );
-
-  const roles = response.result || [];
-  if (roles.length === 0) {
+  const keys = await getProjectRoleKeys(projectId, ctx);
+  if (keys.length === 0) {
     return textResponse(`No roles found in project ${projectId}.`);
   }
-
-  const lines = roles.map(r => {
+  // Re-fetch with display names for a richer listing.
+  const response = await ctx.client.request<ListProjectRolesResponse>(
+    `/management/v1/projects/${projectId}/roles/_search`,
+    { method: 'POST', body: JSON.stringify({ query: { offset: '0', limit: 100 } }) }
+  );
+  const lines = (response.result || []).map((r) => {
     const group = r.group ? ` (group: ${r.group})` : '';
     return `- ${r.key}: ${r.displayName}${group}`;
   });
-
-  return textResponse(`Found ${roles.length} role(s) in project ${projectId}:\n\n${lines.join('\n')}`);
+  return textResponse(`Found ${lines.length} role(s) in project ${projectId}:\n\n${lines.join('\n')}`);
 };
 
 const createProjectRoleHandler: ToolHandler = async (params, ctx) => {
@@ -155,14 +248,7 @@ const createProjectRoleHandler: ToolHandler = async (params, ctx) => {
 
   await ctx.client.request(
     `/management/v1/projects/${projectId}/roles`,
-    {
-      method: 'POST',
-      body: JSON.stringify({
-        roleKey: input.roleKey,
-        displayName: input.displayName,
-        group: input.group,
-      }),
-    }
+    { method: 'POST', body: JSON.stringify({ roleKey: input.roleKey, displayName: input.displayName, group: input.group }) }
   );
 
   return textResponse(`Role created: ${input.roleKey} (${input.displayName}) in project ${projectId}`);
@@ -172,27 +258,10 @@ const listUserGrantsHandler: ToolHandler = async (params, ctx) => {
   const { userId } = z.object({ userId: zitadelId('userId') }).parse(params);
   const projectId = (params['projectId'] as string) || ctx.config.projectId;
 
-  const queries: unknown[] = [{ userIdQuery: { userId } }];
-  if (projectId) {
-    queries.push({ projectIdQuery: { projectId } });
-  }
-
-  const response = await ctx.client.request<ListUserGrantsResponse>(
-    '/management/v1/users/grants/_search',
-    {
-      method: 'POST',
-      body: JSON.stringify({
-        query: { offset: '0', limit: 100 },
-        queries,
-      }),
-    }
-  );
-
-  const grants = response.result || [];
+  const grants = await listUserProjectGrants(ctx, userId, projectId);
   if (grants.length === 0) {
     return textResponse(`No grants found for user ${userId}.`);
   }
-
   const lines = grants.map(formatGrant);
   return textResponse(`Found ${grants.length} grant(s) for user ${userId}:\n\n${lines.join('\n')}`);
 };
@@ -206,7 +275,7 @@ const createUserGrantHandler: ToolHandler = async (params, ctx) => {
 
   // Validate that roles exist before granting
   const existingRoles = await getProjectRoleKeys(projectId, ctx);
-  const missingRoles = input.roleKeys.filter(r => !existingRoles.includes(r));
+  const missingRoles = input.roleKeys.filter((r) => !existingRoles.includes(r));
   if (missingRoles.length > 0) {
     return errorResponse(
       `Cannot grant access: role(s) not found in project ${projectId}: ${missingRoles.join(', ')}\n` +
@@ -215,22 +284,28 @@ const createUserGrantHandler: ToolHandler = async (params, ctx) => {
     );
   }
 
-  logger.info('Creating user grant', { userId: input.userId, projectId });
+  logger.info('Creating user grant (v2 authorization)', { userId: input.userId, projectId });
 
-  const response = await ctx.client.request<CreateUserGrantResponse>(
-    `/management/v1/users/${input.userId}/grants`,
-    {
-      method: 'POST',
-      body: JSON.stringify({ projectId, roleKeys: input.roleKeys }),
-    }
-  );
+  const { id } = await assignProjectRole(ctx, {
+    userId: input.userId,
+    projectId,
+    roleKeys: input.roleKeys,
+  });
+
+  // Drift guard (§8.1): flag keys outside the standardized two-role vocabulary.
+  const drift = nonStandardRoles(input.roleKeys);
+  const driftNote = drift.length > 0
+    ? `\n\n⚠ Drift: role(s) outside the standardized vocabulary (${RBAC_PROJECT_ROLES.join(' | ')}): ${drift.join(', ')}. ` +
+      `For the core SSO apps, prefer zitadel_provision_user with role admin|standard.`
+    : '';
 
   return textResponse(
-    `Grant created successfully.\n` +
-    `Grant ID: ${response.userGrantId}\n` +
+    `Authorization created successfully.\n` +
+    `Authorization ID: ${id}\n` +
     `User: ${input.userId}\n` +
     `Roles: ${input.roleKeys.join(', ')}\n` +
-    `Project: ${projectId}`
+    `Project: ${projectId}` +
+    driftNote
   );
 };
 
@@ -249,11 +324,7 @@ const removeUserGrantHandler: ToolHandler = async (params, ctx) => {
     );
   }
 
-  await ctx.client.request(
-    `/management/v1/users/${input.userId}/grants/${input.grantId}`,
-    { method: 'DELETE' }
-  );
-
+  await removeProjectGrant(ctx, input.userId, input.grantId);
   return textResponse(`Grant ${input.grantId} removed from user ${input.userId}.`);
 };
 

--- a/src/tools/users.ts
+++ b/src/tools/users.ts
@@ -46,13 +46,14 @@ export const USER_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'zitadel_create_user',
-    description: 'Create a new human user in Zitadel. An invitation email will be sent automatically so the user can set their password.',
+    description: 'Create a new human user in Zitadel. An invitation email will be sent automatically so the user can set their password. Optionally supply your own userId for idempotent retries (a re-create then conflicts cleanly).',
     inputSchema: {
       type: 'object',
       properties: {
         email: { type: 'string', description: 'Email address for the new user' },
         firstName: { type: 'string', description: 'First name' },
         lastName: { type: 'string', description: 'Last name' },
+        userId: { type: 'string', description: 'Optional client-supplied user ID for idempotency (Zitadel generates one if omitted)' },
       },
       required: ['email', 'firstName', 'lastName'],
     },
@@ -194,32 +195,55 @@ const getUserHandler: ToolHandler = async (params, ctx) => {
   return textResponse(lines.join('\n'));
 };
 
+/**
+ * Find a human user by exact email address. Returns the first match or null.
+ * Used for idempotent provisioning (pre-check by email before create).
+ */
+export async function findUserByEmail(ctx: HandlerContext, email: string): Promise<ZitadelUserDetails | null> {
+  const response = await ctx.client.request<ListUsersResponse>('/v2/users', {
+    method: 'POST',
+    body: JSON.stringify({
+      query: { offset: '0', limit: 2 },
+      queries: [{ emailQuery: { emailAddress: email, method: 'TEXT_QUERY_METHOD_EQUALS_IGNORE_CASE' } }],
+    }),
+  });
+  const users = response.result || [];
+  return users.find((u) => u.human?.email?.email?.toLowerCase() === email.toLowerCase()) || users[0] || null;
+}
+
+/** Create a human user via the v2 API; returns the new user id. Supports a client-supplied userId. */
+export async function createHumanUser(
+  ctx: HandlerContext,
+  args: { email: string; firstName: string; lastName: string; userId?: string }
+): Promise<string> {
+  const body: Record<string, unknown> = {
+    profile: { givenName: args.firstName, familyName: args.lastName },
+    email: { email: args.email, isVerified: false },
+  };
+  if (args.userId) body['userId'] = args.userId;
+
+  const response = await ctx.client.request<CreateUserResponse>('/v2/users/human', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+  return response.userId;
+}
+
 const createUserHandler: ToolHandler = async (params, ctx) => {
   const input = z.object({
     email: z.string().email().max(320),
     firstName: z.string().min(1).max(200),
     lastName: z.string().min(1).max(200),
+    userId: zitadelId('userId').optional(),
   }).parse(params);
 
   logger.info('Creating user');
 
-  const response = await ctx.client.request<CreateUserResponse>('/v2/users/human', {
-    method: 'POST',
-    body: JSON.stringify({
-      profile: {
-        givenName: input.firstName,
-        familyName: input.lastName,
-      },
-      email: {
-        email: input.email,
-        isVerified: false,
-      },
-    }),
-  });
+  const userId = await createHumanUser(ctx, input);
 
   return textResponse(
     `User created successfully.\n` +
-    `User ID: ${response.userId}\n` +
+    `User ID: ${userId}\n` +
     `Email: ${input.email}\n` +
     `Name: ${input.firstName} ${input.lastName}\n\n` +
     `An invitation email has been sent to ${input.email} to complete registration.`

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -17,7 +17,7 @@ export interface ToolAnnotations {
 
 export interface ToolMeta {
   readOnly?: boolean;
-  domain: 'users' | 'projects' | 'applications' | 'roles' | 'service-accounts' | 'organizations' | 'utility' | 'portal';
+  domain: 'users' | 'projects' | 'applications' | 'roles' | 'service-accounts' | 'organizations' | 'utility' | 'portal' | 'provisioning';
 }
 
 export interface ToolDefinition {

--- a/src/types/zitadel.ts
+++ b/src/types/zitadel.ts
@@ -246,6 +246,24 @@ export interface CreateUserGrantResponse {
   details: ResourceDetails;
 }
 
+// ─── Authorizations (Role Assignments) — v2 ──────────────────────────────────
+// Zitadel renamed "User Grant" → "Authorization / Role Assignment". The v2
+// AuthorizationService.CreateAuthorization returns `id` (the authorization id),
+// which is the SAME aggregate id as a v1 user grant — so an id obtained here can
+// be removed via the v1 grant DELETE endpoint and vice versa.
+
+export interface CreateAuthorizationRequest {
+  userId: string;
+  projectId: string;
+  organizationId?: string;
+  roleKeys: string[];
+}
+
+export interface CreateAuthorizationResponse {
+  id: string;
+  creationDate?: string;
+}
+
 // ─── Service Accounts (Machine Users) ────────────────────────────────────────
 
 export interface CreateMachineUserRequest {
@@ -295,4 +313,36 @@ export interface GetOrgResponse {
 export interface ListOrgsResponse {
   details: ListDetails;
   result: ZitadelOrg[];
+}
+
+// ─── Org Members (Managers / Administrators) ─────────────────────────────────
+// "Manager roles" (ORG_OWNER, ORG_USER_MANAGER, …) are distinct from project
+// (business) roles. They grant the ability to administer Zitadel itself and do
+// NOT appear in the OIDC token. Managed via Management API v1 org-member endpoints.
+
+export interface OrgMember {
+  userId: string;
+  roles: string[];
+  preferredLoginName?: string;
+  email?: string;
+  firstName?: string;
+  lastName?: string;
+  displayName?: string;
+  avatarUrl?: string;
+  userType?: string;
+  userResourceOwner?: string;
+  details?: ResourceDetails;
+}
+
+export interface ListOrgMembersResponse {
+  details: ListDetails;
+  result: OrgMember[];
+}
+
+export interface ListOrgMemberRolesResponse {
+  result: string[];
+}
+
+export interface AddOrgMemberResponse {
+  details: ResourceDetails;
 }

--- a/src/utils/rbac.ts
+++ b/src/utils/rbac.ts
@@ -1,0 +1,59 @@
+/**
+ * RBAC vocabulary — the single source of truth for the standardized two-role
+ * model used across the Renewal Initiatives core apps.
+ *
+ * Background: zitadel-background.md §4 (two-role model), §7 (no-super-admin),
+ * §8.1 (constrain role grants to admin|standard to prevent drift back to ad-hoc
+ * app:* keys).
+ *
+ * Two distinct kinds of "role" (§7):
+ *  - PROJECT (business) roles — appear in the OIDC token, gate what a user can do
+ *    inside the apps. We standardize on exactly two: `admin` and `standard`.
+ *  - ORG MANAGER roles — administer Zitadel itself (create users, assign roles).
+ *    NOT in the token. The no-super-admin pattern gives every Admin an
+ *    ORG_USER_MANAGER grant so any Admin can manage any user.
+ */
+
+import { z } from 'zod';
+
+// ─── Project (business) roles — land in the OIDC token ───────────────────────
+
+export const RBAC_PROJECT_ROLES = ['admin', 'standard'] as const;
+export type RbacProjectRole = (typeof RBAC_PROJECT_ROLES)[number];
+
+/** Zod enum for the two-role vocabulary. Rejects any drift (e.g. `app:finance`). */
+export const rbacProjectRoleSchema = z.enum(RBAC_PROJECT_ROLES);
+
+/** True if every key is part of the standardized two-role vocabulary. */
+export function isRbacRoleSet(roleKeys: string[]): boolean {
+  return roleKeys.every((k) => (RBAC_PROJECT_ROLES as readonly string[]).includes(k));
+}
+
+/** Keys that fall outside the two-role vocabulary (drift candidates). */
+export function nonStandardRoles(roleKeys: string[]): string[] {
+  return roleKeys.filter((k) => !(RBAC_PROJECT_ROLES as readonly string[]).includes(k));
+}
+
+// ─── Org manager (administrator) roles — administer Zitadel, NOT in token ─────
+
+/**
+ * The org-manager roles relevant to the SSO/RBAC pattern. ORG_USER_MANAGER is
+ * the least-privilege role that still allows full user lifecycle + role-grant
+ * management within the org (§7) — the default for flat, equal Admins.
+ * ORG_USER_PERMISSION_EDITOR is included because Zitadel may require it
+ * alongside ORG_USER_MANAGER to edit authorizations (to be confirmed live, §9).
+ */
+export const ORG_MANAGER_ROLES = [
+  'ORG_USER_MANAGER',
+  'ORG_OWNER',
+  'ORG_USER_PERMISSION_EDITOR',
+] as const;
+export type OrgManagerRole = (typeof ORG_MANAGER_ROLES)[number];
+
+/** The least-privilege manager role each Admin receives in the no-super-admin model. */
+export const DEFAULT_ADMIN_MANAGER_ROLE: OrgManagerRole = 'ORG_USER_MANAGER';
+
+/** The role that confers full org control — guarded against last-owner removal. */
+export const ORG_OWNER_ROLE = 'ORG_OWNER';
+
+export const orgManagerRoleSchema = z.enum(ORG_MANAGER_ROLES);


### PR DESCRIPTION
Implements the Renewal Initiatives no-super-admin SSO/RBAC model (`sso/zitadel-background.md` §6–§8). **27 → 33 tools.**

## New tools
- **Org managers:** `zitadel_grant_org_manager` / `zitadel_revoke_org_manager` (guards the last `ORG_OWNER`) / `zitadel_list_org_managers` / `zitadel_list_org_manager_roles` — the missing piece for the no-super-admin pattern.
- **`zitadel_provision_user`** — atomic, idempotent: create human user + assign `admin`|`standard` project role + (for Admins) grant `ORG_USER_MANAGER`. Returns `{ zitadelUserId, role, authorizationId, … }`.
- **`zitadel_offboard_user`** — remove role + revoke manager + deactivate, with last-Admin and self-demotion guards.

## Other changes
- Two-role vocabulary (`admin`|`standard`) enforced in provisioning; drift flagged in `create_user_grant` (new `utils/rbac.ts`).
- Role assignment prefers v2 `POST /v2/authorizations` and **auto-falls back to v1 user-grants** when unavailable (verified 404 on our Cloud instance). Client errors now carry `.status`.
- `create_user` accepts a client-supplied `userId` for idempotency.
- `index.ts` loads `.env` from the repo root regardless of CWD, so secrets live in a gitignored `.env` instead of the dotfiles.

## Verification
Live-tested against the instance with throwaways (cleaned up): full provision→offboard lifecycle, org-manager tools, and the v1 fallback. **20 new unit tests, 292 total.** Version 1.0.2 → 1.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)