### PR TITLE
Org login-policy tools + OIDC params, input-validation hardening & service-account key fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,9 @@
 ZITADEL_ISSUER=https://your-instance.zitadel.cloud
 ZITADEL_SERVICE_ACCOUNT_USER_ID=
 ZITADEL_SERVICE_ACCOUNT_KEY_ID=
-ZITADEL_SERVICE_ACCOUNT_PRIVATE_KEY=   # base64-encoded RSA private key
+# RSA private key — the "key" field of the downloaded service-user JSON key. Accepts any of:
+# raw PEM, single-line PEM with escaped "\n", or base64-encoded PEM.
+ZITADEL_SERVICE_ACCOUNT_PRIVATE_KEY=
 ZITADEL_ORG_ID=
 
 # Optional: Default project for role/grant operations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to this fork are documented here. Format loosely follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+This is a fork of [`takleb3rry/zitadel-mcp`](https://github.com/takleb3rry/zitadel-mcp).
+Entries below cover changes made on top of upstream `v1.0.2` (commit `e3bd79c`).
+
+## [Unreleased]
+
+### Added
+
+- **Login-policy tools (org-scoped, ORG_OWNER):**
+  - `zitadel_get_login_policy` — report the current org's login policy: whether
+    self-registration (`allowRegister`) is on, and whether the policy is a custom org
+    policy or inherited from the instance default.
+  - `zitadel_set_self_registration` — enable/disable self-registration for the org by
+    setting `allowRegister`. Idempotent (reads first, no-ops if already in the requested
+    state); creates a custom org policy via `POST` when the org currently inherits the
+    instance default, otherwise `PUT`s the existing one, preserving all other fields.
+  - Stays within the server's least-privilege design: Management API only
+    (`/management/v1/policies/login`), never the Admin API. Enables the Platform Service
+    invitation-accept flow, which requires `allowRegister`
+    (see [zitadel/zitadel#11138](https://github.com/zitadel/zitadel/issues/11138)).
+- **OIDC application parameters** — `grantTypes`, `responseTypes`, and `accessTokenType`
+  on `zitadel_create_oidc_app` / `zitadel_update_app` (e.g. to set the access token type
+  to `JWT`). Cherry-picked from
+  [luuthanhminh/zitadel-mcp@74ff2e0](https://github.com/luuthanhminh/zitadel-mcp/commit/74ff2e0)
+  (authorship preserved).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,11 @@ Entries below cover changes made on top of upstream `v1.0.2` (commit `e3bd79c`).
   to `JWT`). Cherry-picked from
   [luuthanhminh/zitadel-mcp@74ff2e0](https://github.com/luuthanhminh/zitadel-mcp/commit/74ff2e0)
   (authorship preserved).
+
+### Security
+
+- Validate `update_app` redirect / post-logout URIs as URLs (`z.string().url()`), matching
+  `create_oidc_app`; widen debug-log redaction to cover `roleKey` / `roleKeys`,
+  `accessTokenType`, and `expirationDate`. Ported (manually, minus the dependency churn)
+  from [STIFLEUR390/zitadel-mcp@023bf90](https://github.com/STIFLEUR390/zitadel-mcp/commit/023bf90)
+  ("Phase 7: Input validation & redaction hardening").

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server for [
 > *"Provision jane@example.com as an Admin."*
 > — One tool call: creates the user, assigns the `admin` project role (v2 authorization), and grants `ORG_USER_MANAGER` so she can manage other users — no Super Admin required.
 
-## Tools (33)
+## Tools (35)
 
 | Category | Tool | Description |
 |----------|------|-------------|
@@ -22,8 +22,8 @@ An [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server for [
 | | `zitadel_create_project` | Create project |
 | **Applications** | `zitadel_list_apps` | List apps in a project |
 | | `zitadel_get_app` | Get app details + Client ID |
-| | `zitadel_create_oidc_app` | Create OIDC application |
-| | `zitadel_update_app` | Update app (redirect URIs, etc.) |
+| | `zitadel_create_oidc_app` | Create OIDC application (incl. `grantTypes` / `responseTypes` / `accessTokenType`) |
+| | `zitadel_update_app` | Update app (redirect URIs, `accessTokenType`, etc.) |
 | **Roles** | `zitadel_list_project_roles` | List roles in a project |
 | | `zitadel_create_project_role` | Create a role (standardized: `admin`/`standard`) |
 | | `zitadel_list_user_grants` | List user's role grants |
@@ -39,6 +39,8 @@ An [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server for [
 | | `zitadel_create_service_user_key` | Generate key pair |
 | | `zitadel_list_service_user_keys` | List keys (metadata only) |
 | **Organizations** | `zitadel_get_org` | Get current org details |
+| **Login Policy** | `zitadel_get_login_policy` | Get the org login policy (self-registration on/off, custom vs. inherited) |
+| | `zitadel_set_self_registration` | Enable/disable self-registration (`allowRegister`) for the org — idempotent |
 | **Utility** | `zitadel_get_auth_config` | Get .env.local template for an app |
 | **Portal** | `portal_register_app` | Register app in portal DB |
 | | `portal_setup_full_app` | One-click: Zitadel + portal setup |

--- a/src/__tests__/handlers.test.ts
+++ b/src/__tests__/handlers.test.ts
@@ -235,6 +235,135 @@ describe('application handlers', () => {
         )
       ).rejects.toThrow();
     });
+
+    it('passes provided grantTypes + responseTypes to the API', async () => {
+      (ctx.client.request as any).mockResolvedValue({
+        appId: 'app-2',
+        clientId: 'client-2',
+      });
+
+      await APPLICATION_HANDLERS['zitadel_create_oidc_app']!(
+        {
+          projectId: 'p1',
+          name: 'Test',
+          redirectUris: ['https://app.test/cb'],
+          grantTypes: ['OIDC_GRANT_TYPE_AUTHORIZATION_CODE', 'OIDC_GRANT_TYPE_REFRESH_TOKEN'],
+          responseTypes: ['OIDC_RESPONSE_TYPE_CODE'],
+        },
+        ctx
+      );
+
+      const [, options] = (ctx.client.request as any).mock.calls[0];
+      const body = JSON.parse(options.body);
+      expect(body.grantTypes).toEqual([
+        'OIDC_GRANT_TYPE_AUTHORIZATION_CODE',
+        'OIDC_GRANT_TYPE_REFRESH_TOKEN',
+      ]);
+      expect(body.responseTypes).toEqual(['OIDC_RESPONSE_TYPE_CODE']);
+    });
+
+    it('defaults grantTypes to authorization_code when omitted', async () => {
+      (ctx.client.request as any).mockResolvedValue({ appId: 'app-3', clientId: 'client-3' });
+
+      await APPLICATION_HANDLERS['zitadel_create_oidc_app']!(
+        { projectId: 'p1', name: 'Test', redirectUris: ['https://app.test/cb'] },
+        ctx
+      );
+
+      const [, options] = (ctx.client.request as any).mock.calls[0];
+      const body = JSON.parse(options.body);
+      expect(body.grantTypes).toEqual(['OIDC_GRANT_TYPE_AUTHORIZATION_CODE']);
+      expect(body.responseTypes).toEqual(['OIDC_RESPONSE_TYPE_CODE']);
+    });
+  });
+
+  describe('zitadel_update_app', () => {
+    it('replaces grantTypes when provided and preserves untouched fields', async () => {
+      (ctx.client.request as any)
+        .mockResolvedValueOnce({
+          app: {
+            id: 'a1',
+            name: 'Existing',
+            oidcConfig: {
+              clientId: 'c1',
+              redirectUris: ['https://app.test/cb'],
+              responseTypes: ['OIDC_RESPONSE_TYPE_CODE'],
+              grantTypes: ['OIDC_GRANT_TYPE_AUTHORIZATION_CODE'],
+              appType: 'OIDC_APP_TYPE_WEB',
+              authMethodType: 'OIDC_AUTH_METHOD_TYPE_NONE',
+              devMode: false,
+              accessTokenRoleAssertion: true,
+            },
+          },
+        })
+        .mockResolvedValueOnce({});
+
+      await APPLICATION_HANDLERS['zitadel_update_app']!(
+        {
+          projectId: 'p1',
+          appId: 'a1',
+          grantTypes: [
+            'OIDC_GRANT_TYPE_AUTHORIZATION_CODE',
+            'OIDC_GRANT_TYPE_REFRESH_TOKEN',
+          ],
+        },
+        ctx
+      );
+
+      const putCall = (ctx.client.request as any).mock.calls[1];
+      const body = JSON.parse(putCall[1].body);
+      expect(body.grantTypes).toEqual([
+        'OIDC_GRANT_TYPE_AUTHORIZATION_CODE',
+        'OIDC_GRANT_TYPE_REFRESH_TOKEN',
+      ]);
+      // Preserved from current config
+      expect(body.responseTypes).toEqual(['OIDC_RESPONSE_TYPE_CODE']);
+      expect(body.redirectUris).toEqual(['https://app.test/cb']);
+      expect(body.accessTokenRoleAssertion).toBe(true);
+    });
+
+    it('preserves current grantTypes when omitted', async () => {
+      (ctx.client.request as any)
+        .mockResolvedValueOnce({
+          app: {
+            id: 'a1',
+            name: 'Existing',
+            oidcConfig: {
+              clientId: 'c1',
+              redirectUris: ['https://app.test/cb'],
+              responseTypes: ['OIDC_RESPONSE_TYPE_CODE'],
+              grantTypes: [
+                'OIDC_GRANT_TYPE_AUTHORIZATION_CODE',
+                'OIDC_GRANT_TYPE_REFRESH_TOKEN',
+              ],
+              appType: 'OIDC_APP_TYPE_WEB',
+              authMethodType: 'OIDC_AUTH_METHOD_TYPE_NONE',
+            },
+          },
+        })
+        .mockResolvedValueOnce({});
+
+      await APPLICATION_HANDLERS['zitadel_update_app']!(
+        { projectId: 'p1', appId: 'a1', devMode: true },
+        ctx
+      );
+
+      const body = JSON.parse((ctx.client.request as any).mock.calls[1][1].body);
+      expect(body.grantTypes).toEqual([
+        'OIDC_GRANT_TYPE_AUTHORIZATION_CODE',
+        'OIDC_GRANT_TYPE_REFRESH_TOKEN',
+      ]);
+      expect(body.devMode).toBe(true);
+    });
+
+    it('rejects unknown grant type values', async () => {
+      await expect(
+        APPLICATION_HANDLERS['zitadel_update_app']!(
+          { projectId: 'p1', appId: 'a1', grantTypes: ['NOT_A_REAL_GRANT'] },
+          ctx
+        )
+      ).rejects.toThrow();
+    });
   });
 });
 

--- a/src/__tests__/redaction.test.ts
+++ b/src/__tests__/redaction.test.ts
@@ -10,6 +10,9 @@ const REDACTED_FIELDS = new Set([
   'name', 'displayName', 'description', 'query',
   'redirectUris', 'postLogoutRedirectUris',
   'appUrl', 'iconUrl', 'slug',
+  'roleKey', 'roleKeys',
+  'accessTokenType',
+  'expirationDate',
 ]);
 
 function redactArgs(args: Record<string, unknown>): Record<string, unknown> {
@@ -38,7 +41,7 @@ describe('redactArgs', () => {
     expect(result['userName']).toBe('[REDACTED]');
   });
 
-  it('redacts name, displayName, description, query', () => {
+  it('redacts name, displayName, description, query, roleKey', () => {
     const result = redactArgs({
       name: 'My Secret App',
       displayName: 'Admin Role',
@@ -50,7 +53,7 @@ describe('redactArgs', () => {
     expect(result['displayName']).toBe('[REDACTED]');
     expect(result['description']).toBe('[REDACTED]');
     expect(result['query']).toBe('[REDACTED]');
-    expect(result['roleKey']).toBe('admin');
+    expect(result['roleKey']).toBe('[REDACTED]');
   });
 
   it('redacts slug', () => {
@@ -80,7 +83,6 @@ describe('redactArgs', () => {
     const result = redactArgs({
       projectId: 'p1',
       appId: 'a1',
-      roleKey: 'admin',
       limit: 50,
       userId: 'u1',
       grantId: 'g1',
@@ -88,7 +90,6 @@ describe('redactArgs', () => {
     });
     expect(result['projectId']).toBe('p1');
     expect(result['appId']).toBe('a1');
-    expect(result['roleKey']).toBe('admin');
     expect(result['limit']).toBe(50);
     expect(result['userId']).toBe('u1');
     expect(result['grantId']).toBe('g1');

--- a/src/auth/client.ts
+++ b/src/auth/client.ts
@@ -53,12 +53,21 @@ export class ZitadelClient {
 
     const { serviceAccountPrivateKey } = this.config;
 
-    // Decode the base64-encoded private key
-    let privateKeyPem: string;
-    try {
-      privateKeyPem = Buffer.from(serviceAccountPrivateKey, 'base64').toString('utf-8');
-    } catch {
-      privateKeyPem = serviceAccountPrivateKey;
+    // Accept either a raw PEM or a base64-encoded PEM. Base64 decoding never throws,
+    // so a raw PEM run through Buffer.from(_, 'base64') is silently corrupted into
+    // non-PEM bytes — detect a PEM up front instead of relying on try/catch.
+    let privateKeyPem = serviceAccountPrivateKey;
+    if (!privateKeyPem.includes('BEGIN')) {
+      const decoded = Buffer.from(serviceAccountPrivateKey, 'base64').toString('utf-8');
+      if (decoded.includes('BEGIN')) {
+        privateKeyPem = decoded;
+      }
+    }
+
+    // Restore real newlines when the PEM was stored single-line with escaped "\n"
+    // (e.g. the JSON key's "key" field pasted verbatim into an unquoted env var).
+    if (privateKeyPem.includes('\\n')) {
+      privateKeyPem = privateKeyPem.replace(/\\n/g, '\n');
     }
 
     // Convert PKCS#1 to PKCS#8 if needed (jose requires PKCS#8)

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,9 @@ async function main() {
     'name', 'displayName', 'description', 'query',
     'redirectUris', 'postLogoutRedirectUris',
     'appUrl', 'iconUrl', 'slug',
+    'roleKey', 'roleKeys',
+    'accessTokenType',
+    'expirationDate',
   ]);
 
   function redactArgs(args: Record<string, unknown>): Record<string, unknown> {

--- a/src/tools/applications.ts
+++ b/src/tools/applications.ts
@@ -303,8 +303,8 @@ const updateAppHandler: ToolHandler = async (params, ctx) => {
   const input = z.object({
     projectId: zitadelId('projectId'),
     appId: zitadelId('appId'),
-    redirectUris: z.array(z.string().max(2000)).max(20).optional(),
-    postLogoutRedirectUris: z.array(z.string().max(2000)).max(20).optional(),
+    redirectUris: z.array(z.string().url().max(2000)).max(20).optional(),
+    postLogoutRedirectUris: z.array(z.string().url().max(2000)).max(20).optional(),
     grantTypes: z.array(z.enum(GRANT_TYPE_VALUES)).min(1).max(5).optional(),
     responseTypes: z.array(z.enum(RESPONSE_TYPE_VALUES)).min(1).max(3).optional(),
     accessTokenType: z.enum(ACCESS_TOKEN_TYPE_VALUES).optional(),

--- a/src/tools/applications.ts
+++ b/src/tools/applications.ts
@@ -67,6 +67,37 @@ export const APPLICATION_TOOLS: ToolDefinition[] = [
           enum: ['OIDC_AUTH_METHOD_TYPE_BASIC', 'OIDC_AUTH_METHOD_TYPE_POST', 'OIDC_AUTH_METHOD_TYPE_NONE', 'OIDC_AUTH_METHOD_TYPE_PRIVATE_KEY_JWT'],
           description: 'Auth method. Use NONE for PKCE public clients (default: OIDC_AUTH_METHOD_TYPE_NONE)',
         },
+        grantTypes: {
+          type: 'array',
+          items: {
+            type: 'string',
+            enum: [
+              'OIDC_GRANT_TYPE_AUTHORIZATION_CODE',
+              'OIDC_GRANT_TYPE_IMPLICIT',
+              'OIDC_GRANT_TYPE_REFRESH_TOKEN',
+              'OIDC_GRANT_TYPE_DEVICE_CODE',
+              'OIDC_GRANT_TYPE_TOKEN_EXCHANGE',
+            ],
+          },
+          description: 'OAuth grant types (default: [OIDC_GRANT_TYPE_AUTHORIZATION_CODE]). Include OIDC_GRANT_TYPE_REFRESH_TOKEN to issue refresh tokens.',
+        },
+        responseTypes: {
+          type: 'array',
+          items: {
+            type: 'string',
+            enum: [
+              'OIDC_RESPONSE_TYPE_CODE',
+              'OIDC_RESPONSE_TYPE_ID_TOKEN',
+              'OIDC_RESPONSE_TYPE_ID_TOKEN_TOKEN',
+            ],
+          },
+          description: 'OIDC response types (default: [OIDC_RESPONSE_TYPE_CODE]).',
+        },
+        accessTokenType: {
+          type: 'string',
+          enum: ['OIDC_TOKEN_TYPE_BEARER', 'OIDC_TOKEN_TYPE_JWT'],
+          description: 'Access token format. OIDC_TOKEN_TYPE_JWT issues self-contained JWTs validatable via JWKS; OIDC_TOKEN_TYPE_BEARER issues opaque reference tokens. Default OIDC_TOKEN_TYPE_BEARER. Use JWT for resource servers that validate tokens locally (e.g., agentgateway).',
+        },
         devMode: {
           type: 'boolean',
           description: 'Enable dev mode to allow http:// redirect URIs (default: false)',
@@ -79,7 +110,7 @@ export const APPLICATION_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'zitadel_update_app',
-    description: 'Update an OIDC application\'s configuration (redirect URIs, auth method, etc.).',
+    description: 'Update an OIDC application\'s configuration (redirect URIs, auth method, grant types, etc.).',
     inputSchema: {
       type: 'object',
       properties: {
@@ -87,6 +118,37 @@ export const APPLICATION_TOOLS: ToolDefinition[] = [
         appId: { type: 'string', description: 'The application ID to update' },
         redirectUris: { type: 'array', items: { type: 'string' }, description: 'Updated redirect URIs' },
         postLogoutRedirectUris: { type: 'array', items: { type: 'string' }, description: 'Updated post-logout URIs' },
+        grantTypes: {
+          type: 'array',
+          items: {
+            type: 'string',
+            enum: [
+              'OIDC_GRANT_TYPE_AUTHORIZATION_CODE',
+              'OIDC_GRANT_TYPE_IMPLICIT',
+              'OIDC_GRANT_TYPE_REFRESH_TOKEN',
+              'OIDC_GRANT_TYPE_DEVICE_CODE',
+              'OIDC_GRANT_TYPE_TOKEN_EXCHANGE',
+            ],
+          },
+          description: 'Replace OAuth grant types (omit to keep current). Include OIDC_GRANT_TYPE_REFRESH_TOKEN to enable refresh tokens.',
+        },
+        responseTypes: {
+          type: 'array',
+          items: {
+            type: 'string',
+            enum: [
+              'OIDC_RESPONSE_TYPE_CODE',
+              'OIDC_RESPONSE_TYPE_ID_TOKEN',
+              'OIDC_RESPONSE_TYPE_ID_TOKEN_TOKEN',
+            ],
+          },
+          description: 'Replace OIDC response types (omit to keep current).',
+        },
+        accessTokenType: {
+          type: 'string',
+          enum: ['OIDC_TOKEN_TYPE_BEARER', 'OIDC_TOKEN_TYPE_JWT'],
+          description: 'Change access token format. OIDC_TOKEN_TYPE_JWT issues self-contained JWTs (validatable via JWKS); OIDC_TOKEN_TYPE_BEARER issues opaque reference tokens. Omit to keep current.',
+        },
         devMode: { type: 'boolean', description: 'Enable/disable dev mode' },
         accessTokenRoleAssertion: { type: 'boolean', description: 'Include user roles in access tokens' },
         idTokenRoleAssertion: { type: 'boolean', description: 'Include user roles in ID tokens' },
@@ -154,6 +216,7 @@ const getAppHandler: ToolHandler = async (params, ctx) => {
       `Post-Logout URIs: ${(oidc.postLogoutRedirectUris || []).join(', ') || 'none'}`,
       `Response Types: ${(oidc.responseTypes || []).join(', ')}`,
       `Grant Types: ${(oidc.grantTypes || []).join(', ')}`,
+      `Access Token Type: ${oidc.accessTokenType || 'OIDC_TOKEN_TYPE_BEARER (default)'}`,
       `Dev Mode: ${oidc.devMode ?? false}`,
       `Access Token Role Assertion: ${oidc.accessTokenRoleAssertion ?? false}`,
       `ID Token Role Assertion: ${oidc.idTokenRoleAssertion ?? false}`,
@@ -166,6 +229,22 @@ const getAppHandler: ToolHandler = async (params, ctx) => {
   return textResponse(lines.join('\n'));
 };
 
+const GRANT_TYPE_VALUES = [
+  'OIDC_GRANT_TYPE_AUTHORIZATION_CODE',
+  'OIDC_GRANT_TYPE_IMPLICIT',
+  'OIDC_GRANT_TYPE_REFRESH_TOKEN',
+  'OIDC_GRANT_TYPE_DEVICE_CODE',
+  'OIDC_GRANT_TYPE_TOKEN_EXCHANGE',
+] as const;
+
+const RESPONSE_TYPE_VALUES = [
+  'OIDC_RESPONSE_TYPE_CODE',
+  'OIDC_RESPONSE_TYPE_ID_TOKEN',
+  'OIDC_RESPONSE_TYPE_ID_TOKEN_TOKEN',
+] as const;
+
+const ACCESS_TOKEN_TYPE_VALUES = ['OIDC_TOKEN_TYPE_BEARER', 'OIDC_TOKEN_TYPE_JWT'] as const;
+
 const createOIDCAppHandler: ToolHandler = async (params, ctx) => {
   const input = z.object({
     projectId: zitadelId('projectId'),
@@ -174,6 +253,9 @@ const createOIDCAppHandler: ToolHandler = async (params, ctx) => {
     postLogoutRedirectUris: z.array(z.string().url().max(2000)).max(20).optional(),
     appType: z.string().max(50).default('OIDC_APP_TYPE_WEB'),
     authMethodType: z.string().max(50).default('OIDC_AUTH_METHOD_TYPE_NONE'),
+    grantTypes: z.array(z.enum(GRANT_TYPE_VALUES)).min(1).max(5).default(['OIDC_GRANT_TYPE_AUTHORIZATION_CODE']),
+    responseTypes: z.array(z.enum(RESPONSE_TYPE_VALUES)).min(1).max(3).default(['OIDC_RESPONSE_TYPE_CODE']),
+    accessTokenType: z.enum(ACCESS_TOKEN_TYPE_VALUES).optional(),
     devMode: z.boolean().default(false),
   }).parse(params);
 
@@ -186,12 +268,15 @@ const createOIDCAppHandler: ToolHandler = async (params, ctx) => {
       body: JSON.stringify({
         name: input.name,
         redirectUris: input.redirectUris,
-        responseTypes: ['OIDC_RESPONSE_TYPE_CODE'],
-        grantTypes: ['OIDC_GRANT_TYPE_AUTHORIZATION_CODE'],
+        responseTypes: input.responseTypes,
+        grantTypes: input.grantTypes,
         appType: input.appType,
         authMethodType: input.authMethodType,
         postLogoutRedirectUris: input.postLogoutRedirectUris,
         devMode: input.devMode,
+        // Only send accessTokenType when caller specified it; let Zitadel default
+        // (bearer) apply otherwise. Including it as undefined trips the API.
+        ...(input.accessTokenType ? { accessTokenType: input.accessTokenType } : {}),
       }),
     }
   );
@@ -220,6 +305,9 @@ const updateAppHandler: ToolHandler = async (params, ctx) => {
     appId: zitadelId('appId'),
     redirectUris: z.array(z.string().max(2000)).max(20).optional(),
     postLogoutRedirectUris: z.array(z.string().max(2000)).max(20).optional(),
+    grantTypes: z.array(z.enum(GRANT_TYPE_VALUES)).min(1).max(5).optional(),
+    responseTypes: z.array(z.enum(RESPONSE_TYPE_VALUES)).min(1).max(3).optional(),
+    accessTokenType: z.enum(ACCESS_TOKEN_TYPE_VALUES).optional(),
     devMode: z.boolean().optional(),
     accessTokenRoleAssertion: z.boolean().optional(),
     idTokenRoleAssertion: z.boolean().optional(),
@@ -234,12 +322,13 @@ const updateAppHandler: ToolHandler = async (params, ctx) => {
 
   const body: Record<string, unknown> = {
     redirectUris: input.redirectUris ?? oidc?.redirectUris,
-    responseTypes: oidc?.responseTypes,
-    grantTypes: oidc?.grantTypes,
+    responseTypes: input.responseTypes ?? oidc?.responseTypes,
+    grantTypes: input.grantTypes ?? oidc?.grantTypes,
     appType: oidc?.appType,
     authMethodType: oidc?.authMethodType,
     postLogoutRedirectUris: input.postLogoutRedirectUris ?? oidc?.postLogoutRedirectUris,
     devMode: input.devMode ?? oidc?.devMode ?? false,
+    accessTokenType: input.accessTokenType ?? oidc?.accessTokenType,
     accessTokenRoleAssertion: input.accessTokenRoleAssertion ?? oidc?.accessTokenRoleAssertion ?? false,
     idTokenRoleAssertion: input.idTokenRoleAssertion ?? oidc?.idTokenRoleAssertion ?? false,
     idTokenUserinfoAssertion: input.idTokenUserinfoAssertion ?? oidc?.idTokenUserinfoAssertion ?? false,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -11,6 +11,7 @@ import { SERVICE_ACCOUNT_TOOLS, SERVICE_ACCOUNT_HANDLERS } from './service-accou
 import { ORG_TOOLS, ORG_HANDLERS } from './organizations.js';
 import { ORG_MEMBER_TOOLS, ORG_MEMBER_HANDLERS } from './org-members.js';
 import { PROVISIONING_TOOLS, PROVISIONING_HANDLERS } from './provisioning.js';
+import { LOGIN_POLICY_TOOLS, LOGIN_POLICY_HANDLERS } from './login-policy.js';
 import { UTILITY_TOOLS, UTILITY_HANDLERS } from './utility.js';
 import { PORTAL_TOOLS, PORTAL_HANDLERS } from './portal.js';
 import type { ToolDefinition, ToolHandler } from '../types/tools.js';
@@ -27,6 +28,7 @@ export function getTools(config: ZitadelConfig): ToolDefinition[] {
     ...ORG_TOOLS,
     ...ORG_MEMBER_TOOLS,
     ...PROVISIONING_TOOLS,
+    ...LOGIN_POLICY_TOOLS,
     ...UTILITY_TOOLS,
   ];
 
@@ -47,6 +49,7 @@ export function getHandlers(config: ZitadelConfig): Record<string, ToolHandler> 
     ...ORG_HANDLERS,
     ...ORG_MEMBER_HANDLERS,
     ...PROVISIONING_HANDLERS,
+    ...LOGIN_POLICY_HANDLERS,
     ...UTILITY_HANDLERS,
   };
 

--- a/src/tools/login-policy.ts
+++ b/src/tools/login-policy.ts
@@ -1,0 +1,161 @@
+/**
+ * Login-policy tools (2 tools)
+ * Org-level login policy via Zitadel Management API v1 (/management/v1/policies/login).
+ *
+ * Scope note: this stays within the server's least-privilege stance (see auth/client.ts) —
+ * it uses ONLY the org-scoped Management API and an ORG_OWNER service account, never the
+ * Admin API (/admin/v1/policies/login = the instance default, which needs IAM_ADMIN). So it
+ * toggles self-registration for the configured ZITADEL_ORG_ID, not the whole instance. For a
+ * single-org instance that is effectively instance-wide; for a multi-org instance, run it once
+ * per org. Enabling `allowRegister` is what lets invited users finish the registration step on
+ * invite-accept (ZITADEL #11138).
+ */
+
+import { z } from 'zod';
+import type { ToolDefinition, ToolHandler } from '../types/tools.js';
+import { textResponse } from '../types/tools.js';
+import { logger } from '../utils/logger.js';
+
+// ─── Shapes (subset of the Management API login policy) ──────────────────────
+
+interface LoginPolicy {
+  allowRegister?: boolean;
+  allowUsernamePassword?: boolean;
+  allowExternalIdp?: boolean;
+  forceMfa?: boolean;
+  forceMfaLocalOnly?: boolean;
+  passwordlessType?: string;
+  hidePasswordReset?: boolean;
+  ignoreUnknownUsernames?: boolean;
+  allowDomainDiscovery?: boolean;
+  disableLoginWithEmail?: boolean;
+  disableLoginWithPhone?: boolean;
+  defaultRedirectUri?: string;
+  passwordCheckLifetime?: unknown;
+  externalLoginCheckLifetime?: unknown;
+  mfaInitSkipLifetime?: unknown;
+  secondFactorCheckLifetime?: unknown;
+  multiFactorCheckLifetime?: unknown;
+  /** true while the org inherits the instance default (no custom policy yet) */
+  isDefault?: boolean;
+}
+
+interface LoginPolicyResponse {
+  policy: LoginPolicy;
+}
+
+const LOGIN_POLICY_PATH = '/management/v1/policies/login';
+
+// ─── Tool Definitions ────────────────────────────────────────────────────────
+
+export const LOGIN_POLICY_TOOLS: ToolDefinition[] = [
+  {
+    name: 'zitadel_get_login_policy',
+    description:
+      'Get the login policy of the current organization (ZITADEL_ORG_ID), including whether ' +
+      'self-registration (allowRegister) is on and whether the policy is inherited from the ' +
+      'instance default or a custom org policy.',
+    inputSchema: { type: 'object', properties: {} },
+    _meta: { readOnly: true, domain: 'organizations' },
+    annotations: { title: 'Get Login Policy', readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+  },
+  {
+    name: 'zitadel_set_self_registration',
+    description:
+      "Enable or disable self-registration (the login screen's \"Register\" option) for the " +
+      'current organization, by setting allowRegister on its login policy. Idempotent: reads ' +
+      'first and no-ops if already in the requested state. ORG-LEVEL — affects every app whose ' +
+      'login resolves to this org, not a single application. If the org inherits the instance ' +
+      'default, this creates a custom org policy seeded from the current effective settings.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        enabled: { type: 'boolean', description: 'Target state for allowRegister (default: true)' },
+      },
+    },
+    _meta: { readOnly: false, domain: 'organizations' },
+    annotations: { title: 'Set Self-Registration', readOnlyHint: false, destructiveHint: false, idempotentHint: true },
+  },
+];
+
+// ─── Handlers ────────────────────────────────────────────────────────────────
+
+const getLoginPolicyHandler: ToolHandler = async (_params, ctx) => {
+  const res = await ctx.client.request<LoginPolicyResponse>(LOGIN_POLICY_PATH);
+  const p = res.policy ?? {};
+  const orgId = ctx.client.getConfig().orgId;
+
+  const lines = [
+    `Login policy for org ${orgId}:`,
+    `Source: ${p.isDefault ? 'inherited instance default (no custom org policy yet)' : 'custom org policy'}`,
+    `Self-registration (allowRegister): ${p.allowRegister ? 'ENABLED' : 'disabled'}`,
+    `Username/password login: ${p.allowUsernamePassword ? 'enabled' : 'disabled'}`,
+    `External IdP login: ${p.allowExternalIdp ? 'enabled' : 'disabled'}`,
+    `Force MFA: ${p.forceMfa ? 'yes' : 'no'}`,
+  ];
+
+  return textResponse(lines.join('\n'));
+};
+
+const setSelfRegistrationHandler: ToolHandler = async (params, ctx) => {
+  const { enabled } = z.object({ enabled: z.boolean().default(true) }).parse(params);
+  const orgId = ctx.client.getConfig().orgId;
+
+  // 1) Read the org's *effective* policy (returned even while inheriting the instance default).
+  const current = await ctx.client.request<LoginPolicyResponse>(LOGIN_POLICY_PATH);
+  const policy = current.policy ?? {};
+
+  // 2) Idempotent no-op when already in the requested state.
+  if (Boolean(policy.allowRegister) === enabled) {
+    const source = policy.isDefault ? 'inherited from the instance default' : 'custom org policy';
+    return textResponse(
+      `No change: self-registration is already ${enabled ? 'ENABLED' : 'disabled'} for org ${orgId} (${source}).`
+    );
+  }
+
+  // 3) Build the update body: flip allowRegister, preserve every other writable field from the
+  //    effective policy (so creating a custom policy doesn't reset lifetimes/flags to zero).
+  //    secondFactors/multiFactors/idps are managed by separate endpoints — omit them here.
+  const body = {
+    allowUsernamePassword: policy.allowUsernamePassword ?? true,
+    allowRegister: enabled,
+    allowExternalIdp: policy.allowExternalIdp ?? true,
+    forceMfa: policy.forceMfa ?? false,
+    forceMfaLocalOnly: policy.forceMfaLocalOnly ?? false,
+    passwordlessType: policy.passwordlessType ?? 'PASSWORDLESS_TYPE_ALLOWED',
+    hidePasswordReset: policy.hidePasswordReset ?? false,
+    ignoreUnknownUsernames: policy.ignoreUnknownUsernames ?? false,
+    allowDomainDiscovery: policy.allowDomainDiscovery ?? false,
+    disableLoginWithEmail: policy.disableLoginWithEmail ?? false,
+    disableLoginWithPhone: policy.disableLoginWithPhone ?? false,
+    defaultRedirectUri: policy.defaultRedirectUri ?? '',
+    passwordCheckLifetime: policy.passwordCheckLifetime,
+    externalLoginCheckLifetime: policy.externalLoginCheckLifetime,
+    mfaInitSkipLifetime: policy.mfaInitSkipLifetime,
+    secondFactorCheckLifetime: policy.secondFactorCheckLifetime,
+    multiFactorCheckLifetime: policy.multiFactorCheckLifetime,
+  };
+
+  // 4) No custom policy yet (inheriting default) → POST creates one; else PUT updates it.
+  const method = policy.isDefault ? 'POST' : 'PUT';
+  logger.info('Updating org login policy', { method, allowRegister: enabled });
+  await ctx.client.request(LOGIN_POLICY_PATH, { method, body: JSON.stringify(body) });
+
+  const action = policy.isDefault
+    ? 'Created a custom login policy for this org (it previously inherited the instance default)'
+    : 'Updated the existing custom org login policy';
+
+  return textResponse(
+    `Self-registration ${enabled ? 'ENABLED' : 'disabled'} for org ${orgId}.\n` +
+    `${action}.\n\n` +
+    `Impact: this is an ORG-level setting — the "Register" option now ${enabled ? 'appears' : 'is hidden'} ` +
+    `on the login screen for EVERY application whose login resolves to this org, not just one app.`
+  );
+};
+
+// ─── Export ──────────────────────────────────────────────────────────────────
+
+export const LOGIN_POLICY_HANDLERS: Record<string, ToolHandler> = {
+  zitadel_get_login_policy: getLoginPolicyHandler,
+  zitadel_set_self_registration: setSelfRegistrationHandler,
+};

--- a/src/types/zitadel.ts
+++ b/src/types/zitadel.ts
@@ -155,6 +155,7 @@ export interface OIDCConfig {
   authMethodType: string;
   postLogoutRedirectUris?: string[];
   devMode?: boolean;
+  accessTokenType?: string;
   accessTokenRoleAssertion?: boolean;
   idTokenRoleAssertion?: boolean;
   idTokenUserinfoAssertion?: boolean;


### PR DESCRIPTION
## Summary

Four changes, layered on top of `main` (`58f55a5`):

### 1. Org login-policy tools (new) — `src/tools/login-policy.ts`

Two org-scoped tools that stay inside this server's least-privilege design (Management API only, `ORG_OWNER`, **no** Admin API):

- **`zitadel_get_login_policy`** — report the org's login policy: whether self-registration (`allowRegister`) is on, and whether it's a custom org policy or inherited from the instance default.
- **`zitadel_set_self_registration`** `{ enabled }` — idempotently toggle `allowRegister`. Reads first and no-ops if already in the requested state; `POST`s a new custom org policy (seeded from the current effective settings) when the org currently inherits the instance default, otherwise `PUT`s the existing one — changing **only** `allowRegister` and preserving every other field.

Motivation: enabling self-registration is what lets invited users complete the registration step on invite-accept (see zitadel/zitadel#11138). It deliberately targets the **org** policy (`/management/v1/policies/login`), not the instance default (`/admin/v1/policies/login`), to avoid IAM-admin elevation — consistent with the note in `auth/client.ts` and the earlier removal of `zitadel_list_orgs`.

### 2. OIDC application parameters — cherry-picked from @luuthanhminh

`grantTypes`, `responseTypes`, and `accessTokenType` on `zitadel_create_oidc_app` / `zitadel_update_app` (e.g. to set the access token type to `JWT`). Original commit: `luuthanhminh/zitadel-mcp@74ff2e0` (authorship preserved).

### 3. Input-validation & redaction hardening — ported from @STIFLEUR390

- `update_app` redirect / post-logout URIs validated as URLs (`z.string().url()`), matching `create_oidc_app`.
- Debug-log redaction widened to `roleKey` / `roleKeys`, `accessTokenType`, and `expirationDate`.

Ported (manually, minus the dependency-lockfile churn) from `STIFLEUR390/zitadel-mcp@023bf90` ("Phase 7: Input validation & redaction hardening").

### 4. Service-account key decoding fix — `src/auth/client.ts`

`getCryptoKey()` always ran the configured key through `Buffer.from(_, 'base64')` first, inside a `try/catch`. But base64 decoding never throws, so a **raw PEM** — which `.env.example` explicitly documents as a valid format — was silently corrupted into non-PEM bytes and `importPKCS8` rejected it, failing **every** Management API call with an opaque error before any token request was even made. The same path also couldn't handle a single-line PEM stored with literal `\n` escapes (e.g. the downloaded JSON key's `"key"` field pasted into an unquoted env var), which OpenSSL rejects with `ERR_OSSL_UNSUPPORTED`.

Now the value is detected as a PEM **before** any base64 decode, and literal `\n` sequences are normalized to real newlines — so raw PEM, base64-encoded PEM, and escaped-newline PEM all work. Verified end-to-end with a live JWT-bearer token exchange (HTTP 200) against a real instance.

## Notes

- Adds a `CHANGELOG.md` documenting the above; `README.md` tool table updated (33 → 35) and the OIDC-app rows annotated.
- `npm run build` is clean; **296 / 297 tests pass**. The single failure (`create_service_user_key > saves key to file and returns path`) is a **pre-existing** Windows path-separator assertion (`.zitadel-mcp/keys/` vs `\keys\`) unrelated to this PR.
- Happy to split any of the four into separate PRs, add tests for the login-policy tools, or drop the `CHANGELOG.md` if you'd rather not carry one — just say.

Credit: @luuthanhminh (OIDC params), @STIFLEUR390 (Phase 7 hardening).
