### PR TITLE
fix(update-app): preserve accessTokenType on OIDC config update

### DIFF
--- a/src/__tests__/handlers.test.ts
+++ b/src/__tests__/handlers.test.ts
@@ -236,6 +236,39 @@ describe('application handlers', () => {
       ).rejects.toThrow();
     });
   });
+
+  describe('zitadel_update_app', () => {
+    it('preserves accessTokenType when only redirect URIs change', async () => {
+      const req = ctx.client.request as any;
+      req.mockResolvedValueOnce({
+        app: {
+          oidcConfig: {
+            clientId: 'c1',
+            redirectUris: ['https://old/callback'],
+            responseTypes: ['OIDC_RESPONSE_TYPE_CODE'],
+            grantTypes: ['OIDC_GRANT_TYPE_AUTHORIZATION_CODE'],
+            appType: 'OIDC_APP_TYPE_WEB',
+            authMethodType: 'OIDC_AUTH_METHOD_TYPE_NONE',
+            accessTokenType: 'OIDC_TOKEN_TYPE_JWT',
+            clockSkew: '0s',
+            additionalOrigins: ['https://extra'],
+          },
+        },
+      });
+      req.mockResolvedValueOnce({});
+
+      await APPLICATION_HANDLERS['zitadel_update_app']!(
+        { projectId: 'p1', appId: 'a1', redirectUris: ['https://new/callback'] },
+        ctx
+      );
+
+      const putCall = req.mock.calls[1];
+      const body = JSON.parse(putCall[1].body);
+      expect(body.accessTokenType).toBe('OIDC_TOKEN_TYPE_JWT');
+      expect(body.redirectUris).toEqual(['https://new/callback']);
+      expect(body.additionalOrigins).toEqual(['https://extra']);
+    });
+  });
 });
 
 // ─── Role handlers ────────────────────────────────────────────────────────────

--- a/src/tools/applications.ts
+++ b/src/tools/applications.ts
@@ -232,6 +232,10 @@ const updateAppHandler: ToolHandler = async (params, ctx) => {
   );
   const oidc = current.app.oidcConfig;
 
+  // The oidc_config PUT replaces the ENTIRE config, so every field omitted here
+  // is reset to its proto default. Preserve fields this tool does not manage —
+  // notably accessTokenType (dropping it silently reverts JWT apps to opaque
+  // bearer tokens, breaking JWT-verifying resource servers).
   const body: Record<string, unknown> = {
     redirectUris: input.redirectUris ?? oidc?.redirectUris,
     responseTypes: oidc?.responseTypes,
@@ -240,9 +244,12 @@ const updateAppHandler: ToolHandler = async (params, ctx) => {
     authMethodType: oidc?.authMethodType,
     postLogoutRedirectUris: input.postLogoutRedirectUris ?? oidc?.postLogoutRedirectUris,
     devMode: input.devMode ?? oidc?.devMode ?? false,
+    accessTokenType: oidc?.accessTokenType,
     accessTokenRoleAssertion: input.accessTokenRoleAssertion ?? oidc?.accessTokenRoleAssertion ?? false,
     idTokenRoleAssertion: input.idTokenRoleAssertion ?? oidc?.idTokenRoleAssertion ?? false,
     idTokenUserinfoAssertion: input.idTokenUserinfoAssertion ?? oidc?.idTokenUserinfoAssertion ?? false,
+    clockSkew: oidc?.clockSkew,
+    additionalOrigins: oidc?.additionalOrigins,
   };
 
   await ctx.client.request(

--- a/src/types/zitadel.ts
+++ b/src/types/zitadel.ts
@@ -155,9 +155,12 @@ export interface OIDCConfig {
   authMethodType: string;
   postLogoutRedirectUris?: string[];
   devMode?: boolean;
+  accessTokenType?: string;
   accessTokenRoleAssertion?: boolean;
   idTokenRoleAssertion?: boolean;
   idTokenUserinfoAssertion?: boolean;
+  clockSkew?: string;
+  additionalOrigins?: string[];
 }
 
 export interface ZitadelApp {


### PR DESCRIPTION
## Problem

`zitadel_update_app` silently reverts JWT apps to opaque bearer tokens.

The Zitadel `oidc_config` PUT replaces the **entire** config, so any field omitted from the request body is reset to its proto default. The handler rebuilt the body from a fixed field set that excluded `accessTokenType`. Editing redirect URIs (or any managed field) therefore dropped `OIDC_TOKEN_TYPE_JWT` back to the default bearer type.

Resource servers that verify a signed JWT (e.g. an MCP server doing `jwtVerify` against JWKS) then reject every issued token with `invalid_token`, because Zitadel starts minting encrypted/opaque tokens instead of RS256 JWTs.

Hit in the wild: adding a loopback redirect URI to an OAuth app broke every existing MCP client of that app until `accessTokenType` was manually restored.

## Fix

Preserve the fields this tool does not manage from the current config: `accessTokenType`, `clockSkew`, and `additionalOrigins`. Add them to the `OIDCConfig` type and a regression test asserting `accessTokenType` survives a redirect-only update.

## Test

`npm test` — 293 passed, including the new `zitadel_update_app` case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)